### PR TITLE
Test consistency of static GTFS feeds for live agencies

### DIFF
--- a/gtfu/src/main/java/gtfu/EmailFailureReporter.java
+++ b/gtfu/src/main/java/gtfu/EmailFailureReporter.java
@@ -1,0 +1,29 @@
+package gtfu;
+
+import gtfu.tools.SendGrid;
+
+public class EmailFailureReporter extends FailureReporter {
+    private String[]recipients;
+    private String subject;
+
+    public EmailFailureReporter(String[] recipients, String subject) {
+        this.recipients = recipients;
+        this.subject = subject;
+    }
+
+    public void send() {
+        StringBuilder sb = new StringBuilder();
+
+        for (String l : lines) {
+            sb.append(l);
+            sb.append('\n');
+        }
+
+        if (sb.length() == 0) {
+            sb.append("0 lines\n");
+        }
+
+        SendGrid grid = new SendGrid(recipients, subject, sb.toString(), null);
+        grid.send();
+    }
+}

--- a/gtfu/src/main/java/gtfu/FailureReporter.java
+++ b/gtfu/src/main/java/gtfu/FailureReporter.java
@@ -1,0 +1,18 @@
+package gtfu;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class FailureReporter {
+    protected List<String> lines;
+
+    public FailureReporter() {
+        lines = new ArrayList();
+    }
+
+    public void addLine(String s) {
+        lines.add(s);
+    }
+
+    public abstract void send();
+}

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -211,8 +211,8 @@ public class GraphicReport {
 
         String[] recipients = recipientList.split(",");
 
-        SendGrid grid = new SendGrid(recipients, "Automated GRaaS Report", blobs);
-        Integer responseCode = grid.setupThenSend();
+        SendGrid grid = new SendGrid(recipients, "Automated GRaaS Report", "Attached", blobs);
+        int responseCode = grid.send();
         // Debug.log("- responseCode: " + responseCode);
     }
 

--- a/gtfu/src/main/java/gtfu/NullFailureReporter.java
+++ b/gtfu/src/main/java/gtfu/NullFailureReporter.java
@@ -1,0 +1,8 @@
+package gtfu;
+
+public class NullFailureReporter extends FailureReporter {
+    public void send() {
+        Debug.log("NullFailureReporter.send()");
+        Debug.log("+ doing exactly squat");
+    }
+}

--- a/gtfu/src/main/java/gtfu/RouteCollection.java
+++ b/gtfu/src/main/java/gtfu/RouteCollection.java
@@ -19,6 +19,10 @@ public class RouteCollection implements Iterable<Route>, Serializable {
 
     // route_id,route_short_name,route_long_name,route_desc,route_url,route_color,route_text_color,route_type
     public RouteCollection(String path, TripCollection tripCollection) {
+        this(path, tripCollection, false);
+    }
+
+    public RouteCollection(String path, TripCollection tripCollection, boolean skipErrors) {
         this();
 
         TextFile tf = new TextFile(path + "/routes.txt");
@@ -59,14 +63,17 @@ public class RouteCollection implements Iterable<Route>, Serializable {
             Route route = map.get(trip.getRouteID());
 
             if (route == null) {
-                Util.fail(String.format(
-                    "fatal error, trip '%s' references non-existing route ID '%s'",
-                    trip.getID(),
-                    trip.getRouteID()
-                ));
+                Util.fail(
+                    String.format(
+                        "fatal error, trip '%s' references non-existing route ID '%s'",
+                        trip.getID(),
+                        trip.getRouteID()
+                    ),
+                    !skipErrors
+                );
+            } else {
+                route.addTrip(trip);
             }
-
-            route.addTrip(trip);
         }
     }
 

--- a/gtfu/src/main/java/gtfu/RouteCollection.java
+++ b/gtfu/src/main/java/gtfu/RouteCollection.java
@@ -60,7 +60,7 @@ public class RouteCollection implements Iterable<Route>, Serializable {
 
             if (route == null) {
                 Util.fail(String.format(
-                    "*** fatal error, trip '%s' references non-existing route ID '%s'",
+                    "fatal error, trip '%s' references non-existing route ID '%s'",
                     trip.getID(),
                     trip.getRouteID()
                 ));

--- a/gtfu/src/main/java/gtfu/Util.java
+++ b/gtfu/src/main/java/gtfu/Util.java
@@ -73,14 +73,18 @@ public class Util {
     }
 
     public static void fail(String s) {
-        fail(s, reporter);
+        fail(s, true);
     }
 
-    public static void fail(String s, FailureReporter reporter) {
+    public static void fail(String s, boolean except) {
+        fail(s, reporter, except);
+    }
+
+    public static void fail(String s, FailureReporter reporter, boolean except) {
         Debug.error(s);
         reporter.addLine("* " + s);
 
-        throw new Fail(s);
+        if (except) throw new Fail(s);
     }
 
     public static String base64Encode(String s) {
@@ -775,7 +779,7 @@ public class Util {
     }
 
     public static String getGTFSURL(AgencyData[] list, String id) {
-        //Debug.log("Util.loadCollections()");
+        //Debug.log("Util.getGTFSURL()");
         //Debug.log("- id: " + id);
 
         for (AgencyData d : list) {
@@ -788,6 +792,10 @@ public class Util {
     }
 
     public static Map<String, Object> loadCollections(String cacheRoot, String agencyID, ProgressObserver po) {
+        return loadCollections(cacheRoot, agencyID, po, false);
+    }
+
+    public static Map<String, Object> loadCollections(String cacheRoot, String agencyID, ProgressObserver po, boolean skipErrors) {
         Debug.log("Util.loadCollections()");
 
         String path = cacheRoot + "/"  + agencyID;
@@ -827,7 +835,7 @@ public class Util {
 
         //Debug.log("routes:");
         t = new Timer("routes");
-        RouteCollection routeCollection = new RouteCollection(path, tripCollection);
+        RouteCollection routeCollection = new RouteCollection(path, tripCollection, skipErrors);
         collections.put("routes", routeCollection);
         t.dumpLap();
 

--- a/gtfu/src/main/java/gtfu/Util.java
+++ b/gtfu/src/main/java/gtfu/Util.java
@@ -44,6 +44,10 @@ public class Util {
     private final static int EARTH_RADIUS_IN_FEET = 20902231;
     private static final String WHITESPACE = " \t\r\n";
 
+    private static FailureReporter NULL_REPORTER = new NullFailureReporter();
+
+    private static FailureReporter reporter = NULL_REPORTER;
+
     public static String repeat(char c, int count) {
         StringBuffer sb = new StringBuffer();
 
@@ -64,9 +68,18 @@ public class Util {
         throw new Fail("Implement me!");
     }
 
+    public static void setReporter(FailureReporter reporter) {
+        Util.reporter = reporter;
+    }
+
     public static void fail(String s) {
+        fail(s, reporter);
+    }
+
+    public static void fail(String s, FailureReporter reporter) {
         Debug.error(s);
-        // ### TODO: post message to slack graas_internal using webhooks
+        reporter.addLine("* " + s);
+
         throw new Fail(s);
     }
 
@@ -318,9 +331,14 @@ public class Util {
         return value;
     }
 
+    public static String getURLContent(String url, ProgressObserver observer) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        downloadURLContent(url, bos, observer);
+        return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+    }
+
     public static void downloadURLContent(String url, OutputStream os, ProgressObserver observer) {
         HttpURLConnection con = null;
-        StringBuilder content = new StringBuilder("");
 
         try {
             URL myurl = new URL(url);

--- a/gtfu/src/test/java/gtfu/test/LoadAgencyDataTest.java
+++ b/gtfu/src/test/java/gtfu/test/LoadAgencyDataTest.java
@@ -27,7 +27,7 @@ public class LoadAgencyDataTest {
         ConsoleProgressObserver progressObserver = new ConsoleProgressObserver(40);
         Util.updateCacheIfNeeded(cacheDir, agencyID, gtfsUrl, progressObserver);
 
-        Map<String, Object> collections = Util.loadCollections(cacheDir, agencyID, progressObserver);
+        Map<String, Object> collections = Util.loadCollections(cacheDir, agencyID, progressObserver, true);
 
         TripCollection tripCollection = (TripCollection)collections.get("trips");
         Debug.log("- tripCollection.getSize(): " + tripCollection.getSize());

--- a/gtfu/src/test/java/gtfu/test/LoadAgencyDataTest.java
+++ b/gtfu/src/test/java/gtfu/test/LoadAgencyDataTest.java
@@ -4,6 +4,9 @@ import java.util.Map;
 
 import gtfu.ConsoleProgressObserver;
 import gtfu.Debug;
+import gtfu.EmailFailureReporter;
+import gtfu.FailureReporter;
+import gtfu.ProgressObserver;
 import gtfu.Util;
 import gtfu.TripCollection;
 import gtfu.RouteCollection;
@@ -38,12 +41,27 @@ public class LoadAgencyDataTest {
 
     private static void usage() {
         System.err.println("usage: LoadAgencyDataTest -c|--cache-dir <cache-dir> -a|--agency-id <agency-id>");
+        System.err.println("usage: LoadAgencyDataTest -c|--cache-dir <cache-dir> -u|--url <url>");
+        System.err.println("    <url> is assumed to point to a plain text document that has an agency ID per line");
         System.exit(1);
     }
 
     public static void main(String[] arg) throws Exception {
         String cacheDir = null;
         String agencyID = null;
+        String url = null;
+
+        String r = System.getenv("GRAAS_REPORT_RECIPIENTS");
+
+        if (r == null) {
+            System.err.println("* missing recipient list, please set GRAAS_REPORT_RECIPIENTS env variable");
+            System.exit(1);
+        }
+
+        String[] recipients = r.split(", ");
+
+        FailureReporter reporter = new EmailFailureReporter(recipients, "LoadAgencyDataTest Report");
+        Util.setReporter(reporter);
 
         for (int i=0; i<arg.length; i++) {
             if ((arg[i].equals("-c") || arg[i].equals("--cache-dir")) && i < arg.length - 1) {
@@ -56,11 +74,42 @@ public class LoadAgencyDataTest {
                 continue;
             }
 
+            if ((arg[i].equals("-u") || arg[i].equals("--url")) && i < arg.length - 1) {
+                url = arg[++i];
+                continue;
+            }
+
             usage();
         }
 
-        if (cacheDir == null || agencyID == null) usage();
+        if (cacheDir == null || (agencyID == null && url == null)) usage();
 
-        new LoadAgencyDataTest(cacheDir, agencyID);
+        if (url == null) {
+            reporter.addLine("agency: " + agencyID);
+
+            try {
+                new LoadAgencyDataTest(cacheDir, agencyID);
+            } catch (Exception e) {
+                Debug.error("* test failed: " + e);
+            }
+        } else {
+            ProgressObserver po = new ConsoleProgressObserver(40);
+            String context = Util.getURLContent(url, po);
+            String[] agencyIDList = context.split("\n");
+
+            for (String id : agencyIDList) {
+                Debug.log("-- id: " + id);
+
+                reporter.addLine("agency: " + id);
+
+                try {
+                    new LoadAgencyDataTest(cacheDir, id);
+                } catch (Exception e) {
+                    Debug.error("* test failed: " + e);
+                }
+            }
+        }
+
+        reporter.send();
     }
 }


### PR DESCRIPTION
`LoadAgencyDataTest` pulls a list of agencies from a configurable URL and checks the consistency of their static GTFS data. Failures are recorded and once the test completes, these failures are emailed to recipients listed in the environment variable `GRAAS_REPORT_RECIPIENTS`. 

No slack integration at the moment, since our free plan is constantly out of slack apps, of which we would need one :[ 