### PR TITLE
add new attributes to graphicreport

### DIFF
--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -88,3 +88,18 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### UA Parser - Java
+Copyright 2012 Twitter, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/gtfu/build.gradle
+++ b/gtfu/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile "com.google.cloud:google-cloud-datastore:1.2.1"
     compile "org.apache.httpcomponents.client5:httpclient5:5.1"
     compile "com.googlecode.json-simple:json-simple:1.1.1"
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
+    testImplementation "org.junit.jupiter:junit-jupiter:5.7.1"
 }
 
 jar {

--- a/gtfu/build.gradle
+++ b/gtfu/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile "com.google.cloud:google-cloud-datastore:1.2.1"
     compile "org.apache.httpcomponents.client5:httpclient5:5.1"
     compile "com.googlecode.json-simple:json-simple:1.1.1"
+    compile "com.github.ua-parser:uap-java:1.5.2"
     testImplementation "org.junit.jupiter:junit-jupiter:5.7.1"
 }
 

--- a/gtfu/src/main/java/gtfu/ArrivalPrediction.java
+++ b/gtfu/src/main/java/gtfu/ArrivalPrediction.java
@@ -18,7 +18,7 @@ public class ArrivalPrediction implements Comparable<ArrivalPrediction>, Seriali
     }
 
     public String getArrivalString() {
-        return vehicle.trip.getName() + " in " + minutes + " minutes";
+        return vehicle.trip.getHeadsign() + " in " + minutes + " minutes";
     }
 
     public String toString() {

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -43,6 +43,7 @@ public class GraphicReport {
     private static final Color BACKGROUND = new Color(0xffffff);
     private static final Color DARK       = new Color(0xe0e0e0);
     private static final Color FONT_COLOR = Color.gray;
+    private static final Color TITLE_COLOR = Color.black;
     private static final Color ACCENT     = new Color(0x00b000);
     /*private static final Color BACKGROUND = new Color(0x1c3a08);
     private static final Color DARK       = new Color(0x324e34);
@@ -50,7 +51,7 @@ public class GraphicReport {
     private static final Color ACCENT     = new Color(0xd8ebb5);*/
 
     private static final String[] PROPERTY_NAMES = {
-        "vehicle-id", "timestamp", "lat", "long", "trip-id", "agency-id"
+        "vehicle-id", "timestamp", "lat", "long", "trip-id", "agency-id", "uuid", "agent"
     };
     private static final int SCALE = 2;
     private static final int CANVAS_WIDTH = 1200 * SCALE;
@@ -126,7 +127,7 @@ public class GraphicReport {
             }
 
             List<String> lines = logs.get(key);
-            DayLogSlicer dls = new DayLogSlicer(tripCollection, lines);
+            DayLogSlicer dls = new DayLogSlicer(tripCollection, routeCollection, lines);
             map = dls.getMap();
             tdList = dls.getTripReportDataList();
             tdMap = dls.getTripReportDataMap();
@@ -253,7 +254,7 @@ public class GraphicReport {
                     int t2 = t.getTimeAt(t.getStopSize() - 1);
                     int duration = t2 - t1;
 
-                    TripReportData td = new TripReportData(id, t.getName(), start, duration);
+                    TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration,"testUuid","testAgent","testVehicleId");
                     tdList.add(td);
                     tdMap.put(id, td);
 
@@ -391,12 +392,13 @@ public class GraphicReport {
             g.drawLine(x * TILE_SIZE, 0, x * TILE_SIZE, TILE_SIZE * tileRowCount);
         }
 
+        int lineHeight = (int)(font.getSize() * 1.33);
         int inset = TILE_SIZE / 10;
-        int length = TILE_SIZE - 2 * inset;
+        int length = TILE_SIZE - lineHeight * 4 - inset;
 
         for (int i=0; i<tdList.size(); i++) {
+
             TripReportData td = tdList.get(i);
-            //Debug.log("-- td.id: " + td.id);
 
             x = i % tilesPerRow * TILE_SIZE;
             y = i / tilesPerRow * TILE_SIZE;
@@ -404,8 +406,20 @@ public class GraphicReport {
             String s  = td.getTripName();
             FontMetrics fm = g.getFontMetrics();
             int sw = fm.stringWidth(s);
+            g.setColor(TITLE_COLOR);
+            y = y + lineHeight;
+            g.drawString(s, x + (TILE_SIZE - sw) / 2 , y);
+
             g.setColor(FONT_COLOR);
-            g.drawString(s, x + (TILE_SIZE - sw) / 2, y + (int)(font.getSize() * 1.33));
+            s = "a: " + td.getAgent();
+            sw = fm.stringWidth(s);
+            y = y + lineHeight;
+            g.drawString(s, x + (TILE_SIZE - sw) / 2, y);
+
+            s = "v: " + td.getVehicleId() + ", u: " + td.getUuidTail();
+            sw = fm.stringWidth(s);
+            y = y + lineHeight;
+            g.drawString(s, x + (TILE_SIZE - sw) / 2, y);
 
             AffineTransform t = g.getTransform();
 

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -411,12 +411,12 @@ public class GraphicReport {
             g.drawString(s, x + (TILE_SIZE - sw) / 2 , y);
 
             g.setColor(FONT_COLOR);
-            s = "a: " + td.getAgent();
+            s = "a: " + td.getAgent() + " o: " + td.getOs();
             sw = fm.stringWidth(s);
             y = y + lineHeight;
             g.drawString(s, x + (TILE_SIZE - sw) / 2, y);
 
-            s = "v: " + td.getVehicleId() + ", u: " + td.getUuidTail();
+            s =  "d: " + td.getDevice() + " v: " + td.getVehicleId() + ", u: " + td.getUuidTail();
             sw = fm.stringWidth(s);
             y = y + lineHeight;
             g.drawString(s, x + (TILE_SIZE - sw) / 2, y);

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -257,7 +257,7 @@ public class GraphicReport {
                     int t2 = t.getTimeAt(t.getStopSize() - 1);
                     int duration = t2 - t1;
 
-                    TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration,"testUuid","testAgent","testVehicleId");
+                    TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "testUuid", "testAgent", "testVehicleId");
                     tdList.add(td);
                     tdMap.put(id, td);
 

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -410,6 +410,7 @@ public class GraphicReport {
             y = y + lineHeight;
             g.drawString(s, x + (TILE_SIZE - sw) / 2 , y);
 
+            // TODO: dynamic text formatting/resizing to prevent overflow
             g.setColor(FONT_COLOR);
             s = "a: " + td.getAgent() + " o: " + td.getOs();
             sw = fm.stringWidth(s);

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -10,6 +10,8 @@ import java.awt.FontMetrics;
 import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
+import java.awt.geom.Rectangle2D;
+
 import java.awt.geom.Path2D;
 
 import javax.imageio.ImageIO;
@@ -67,6 +69,7 @@ public class GraphicReport {
     private Map<String, TripReportData> tdMap;
     private BufferedImage img;
     private Ellipse2D.Float dot = new Ellipse2D.Float(0, 0, 1.75f * SCALE, 1.75f * SCALE);
+    private Rectangle2D clipRect = new Rectangle2D.Float();
     private Font font;
     private Font smallFont;
     private int timeRowCount;
@@ -399,18 +402,19 @@ public class GraphicReport {
         for (int i=0; i<tdList.size(); i++) {
 
             TripReportData td = tdList.get(i);
-
             x = i % tilesPerRow * TILE_SIZE;
             y = i / tilesPerRow * TILE_SIZE;
-
             String s  = td.getTripName();
             FontMetrics fm = g.getFontMetrics();
             int sw = fm.stringWidth(s);
             g.setColor(TITLE_COLOR);
+            // TODO: dynamic text formatting/resizing to prevent overflow. For now we just clip:
+            clipRect.setRect(x, y,TILE_SIZE,TILE_SIZE);
+            g.setClip(clipRect);
             y = y + lineHeight;
             g.drawString(s, x + (TILE_SIZE - sw) / 2 , y);
 
-            // TODO: dynamic text formatting/resizing to prevent overflow
+
             g.setColor(FONT_COLOR);
             s = "a: " + td.getAgent() + " o: " + td.getOs();
             sw = fm.stringWidth(s);
@@ -427,8 +431,11 @@ public class GraphicReport {
             g.translate(x + inset, y + inset);
             drawMap(g, td, length);
 
+
             g.setTransform(t);
         }
+
+        g.setClip(null);
     }
 
     private void drawMap(Graphics2D g, TripReportData td, int length) {

--- a/gtfu/src/main/java/gtfu/Trip.java
+++ b/gtfu/src/main/java/gtfu/Trip.java
@@ -13,7 +13,7 @@ public class Trip implements Serializable {
     String id;
     String routeID;
     String serviceID;
-    String name;
+    String headsign;
     List<Stop> stopList;
     List<Integer> milliList;
     Map<String, Integer> stopMap;
@@ -23,13 +23,13 @@ public class Trip implements Serializable {
     int accelerator;
     int startTime;
 
-    public Trip(String id, String routeID, String serviceID, String name, Shape shape) {
+    public Trip(String id, String routeID, String serviceID, String headsign, Shape shape) {
         this();
 
         this.id = id;
         this.routeID = routeID;
         this.serviceID = serviceID;
-        this.name = name;
+        this.headsign = headsign;
         this.shape = shape;
         shapeID = shape.getID();
         //Debug.log("- shapeID: " + shapeID);
@@ -56,7 +56,7 @@ public class Trip implements Serializable {
         try {
             out.writeUTF(id);
             out.writeUTF(routeID);
-            out.writeUTF(name);
+            out.writeUTF(headsign);
 
             out.writeInt(stopList.size());
 
@@ -85,7 +85,7 @@ public class Trip implements Serializable {
 
             t.id = in.readUTF();
             t.routeID = in.readUTF();
-            t.name = in.readUTF();
+            t.headsign = in.readUTF();
 
             int count = in.readInt();
 
@@ -134,8 +134,8 @@ public class Trip implements Serializable {
         return Time.getHMForMillis(e.daySeconds * 1000);
     }
 
-    public String getName() {
-        return name;
+    public String getHeadsign() {
+        return headsign;
     }
 
     public TripSchedule getSchedule() {

--- a/gtfu/src/main/java/gtfu/TripReportData.java
+++ b/gtfu/src/main/java/gtfu/TripReportData.java
@@ -1,4 +1,6 @@
 package gtfu;
+import ua_parser.Parser;
+import ua_parser.Client;
 
 public class TripReportData implements Comparable<TripReportData> {
     public String id;
@@ -12,6 +14,8 @@ public class TripReportData implements Comparable<TripReportData> {
     String uuid;
     String agent;
     String vehicleId;
+    Client deviceClient;
+    Parser uaParser = new Parser();
 
     public TripReportData(String id, String name, int start, int duration, String uuid, String agent, String vehicleId) {
         this.id = id;
@@ -21,6 +25,7 @@ public class TripReportData implements Comparable<TripReportData> {
         this.uuid = uuid;
         this.agent = agent;
         this.vehicleId = vehicleId;
+        this.deviceClient = uaParser.parse(agent);
     }
 
     public int compareTo(TripReportData o) {
@@ -37,7 +42,25 @@ public class TripReportData implements Comparable<TripReportData> {
     }
 
     public String getAgent() {
-        return agent;
+        String userAgentFamily = deviceClient.userAgent.family;
+        String userAgentMajor = deviceClient.userAgent.major;
+        String userAgentMinor = deviceClient.userAgent.minor;
+
+        return userAgentFamily + ((userAgentMajor == null) ? "" :
+                    ((userAgentMinor == null) ? "." + userAgentMajor :  "." + userAgentMajor + "." + userAgentMinor));
+    }
+
+    public String getOs() {
+        String osFamily = deviceClient.os.family;
+        String osMajor = deviceClient.os.major;
+        String osMinor = deviceClient.os.minor;
+
+        return osFamily + ((osMajor == null) ? "" :
+                    ((osMinor == null) ? "." + osMajor :  "." + osMajor + "." + osMinor));
+    }
+
+    public String getDevice() {
+        return deviceClient.device.family;
     }
 
     public String getVehicleId() {

--- a/gtfu/src/main/java/gtfu/TripReportData.java
+++ b/gtfu/src/main/java/gtfu/TripReportData.java
@@ -2,28 +2,46 @@ package gtfu;
 
 public class TripReportData implements Comparable<TripReportData> {
     public String id;
-    String routeName;
+    String name;
     int start;
     int duration;
     int x;
     int y;
     int width;
     int height;
+    String uuid;
+    String agent;
+    String vehicleId;
 
-    public TripReportData(String id, String routeName, int start, int duration) {
+    public TripReportData(String id, String name, int start, int duration, String uuid, String agent, String vehicleId) {
         this.id = id;
-        this.routeName = routeName;
+        this.name = name;
         this.start = start;
         this.duration = duration;
+        this.uuid = uuid;
+        this.agent = agent;
+        this.vehicleId = vehicleId;
     }
 
     public int compareTo(TripReportData o) {
         return start - o.start;
     }
 
-    // Combining route name with start time creates a trip name
+    // Combining name with start time creates a trip name
     public String getTripName() {
-        return getCleanRouteName() + " @ " + Time.getHMForMillis(start);
+        return getCleanName() + " @ " + Time.getHMForMillis(start);
+    }
+
+    public String getUuidTail() {
+        return uuid.substring(uuid.length() - 4, uuid.length());
+    }
+
+    public String getAgent() {
+        return agent;
+    }
+
+    public String getVehicleId() {
+        return vehicleId;
     }
 
     public boolean overlaps(TripReportData td) {
@@ -33,8 +51,8 @@ public class TripReportData implements Comparable<TripReportData> {
 
     // This logic performs cleanup on use cases that may or may not still be present.
     // TODO: Consider removing
-    private String getCleanRouteName() {
-        String s = new String(routeName);
+    private String getCleanName() {
+        String s = new String(name);
         int i = s.length();
 
         int i1 = s.indexOf('(');

--- a/gtfu/src/main/java/gtfu/TripReportData.java
+++ b/gtfu/src/main/java/gtfu/TripReportData.java
@@ -25,6 +25,7 @@ public class TripReportData implements Comparable<TripReportData> {
         this.uuid = uuid;
         this.agent = agent;
         this.vehicleId = vehicleId;
+        // TODO: Create new file for getting deviceClient info
         this.deviceClient = uaParser.parse(agent);
     }
 

--- a/gtfu/src/main/java/gtfu/Vehicle.java
+++ b/gtfu/src/main/java/gtfu/Vehicle.java
@@ -41,7 +41,7 @@ public class Vehicle implements Filterable, GeoObject, Serializable {
     }
 
     public String[] getLabelText() {
-        String label = trip.getName() + ": ";
+        String label = trip.getHeadsign() + ": ";
 
         if (Math.abs(scheduleOffset) < Time.SECONDS_PER_DAY) {
             label += Time.getTimeDeltaString(scheduleOffset, true);

--- a/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
+++ b/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
@@ -9,32 +9,53 @@ import java.util.List;
 import gtfu.GPSData;
 import gtfu.Trip;
 import gtfu.TripCollection;
+import gtfu.RouteCollection;
+import gtfu.Route;
 import gtfu.TripReportData;
 import gtfu.Debug;
 
 public class DayLogSlicer {
     private Map<String, List<GPSData>> gpsMap;
+    private Map<String, String> uuidMap;
+    private Map<String, String> agentMap;
+    private Map<String, String> vehicleIdMap;
     private List<TripReportData> tdList;
     private Map<String, TripReportData> tdMap;
     private int startSecond;
 
-    public DayLogSlicer(TripCollection tripCollection, List<String> lines) {
+    public DayLogSlicer(TripCollection tripCollection, RouteCollection routeCollection, List<String> lines) {
         gpsMap = new HashMap();
+        uuidMap = new HashMap();
+        agentMap = new HashMap();
+        vehicleIdMap = new HashMap();
         tdList = new ArrayList();
         tdMap = new HashMap();
         startSecond = -1;
 
         for (String line : lines) {
             String[] arg = line.split(",");
+            String vehicleId =  arg[0];
             int seconds = Integer.parseInt(arg[1]);
             float lat = Float.parseFloat(arg[2]);
             float lon = Float.parseFloat(arg[3]);
             String tripID = arg[4];
+            String uuid = arg[6];
+            String agent = null;
+            //If agent is array of strings, extract the string value
+            //There may be unexpected behavior if multiple strings in array
+            //TODO: consider updating graas.js to send string rather than array of strings
+            if(arg[7].contains("StringValue")){
+                agent = arg[10];
+                agent = agent.substring(8,agent.length() - 3);
+            } else agent = arg[7];
 
             if (startSecond < 0) {
                 startSecond = seconds;
             }
 
+            vehicleIdMap.put(tripID,vehicleId);
+            uuidMap.put(tripID,uuid);
+            agentMap.put(tripID,agent);
             List<GPSData> list = gpsMap.get(tripID);
 
             if (list == null) {
@@ -54,6 +75,13 @@ public class DayLogSlicer {
                 System.err.println("* no trip found for id " + id + ", skipping");
                 continue;
             }
+            String name = trip.getHeadsign();
+            // Default to trip_headsign. Use routeName if null
+            if (name == null){
+                String route_id = trip.getRouteID();
+                Route route = routeCollection.get(route_id);
+                name = route.getName();
+            }
 
             // Debug.log("++ id: " + trip.getName());
 
@@ -70,7 +98,7 @@ public class DayLogSlicer {
 
             // Filter out trips shorter than 15 min
             if (durationMins >= 15) {
-                TripReportData td = new TripReportData(id, trip.getName(), start, duration);
+                TripReportData td = new TripReportData(id, name, start, duration, uuidMap.get(id), agentMap.get(id), vehicleIdMap.get(id));
                 tdList.add(td);
                 tdMap.put(id, td);
             }

--- a/gtfu/src/main/java/gtfu/tools/TrainingDataUtil.java
+++ b/gtfu/src/main/java/gtfu/tools/TrainingDataUtil.java
@@ -24,6 +24,7 @@ public class TrainingDataUtil {
     private static void processGraphicReportOutput(String dataFile, String mapFile, String cacheDir, String outputDir) throws Exception {
         List<String> lines = Util.getFileContentsAsStrings(dataFile);
         TripCollection tripCollection;
+        RouteCollection routeCollection;
         ShapeCollection shapeCollection;
         List<BufferedImage> tileList = getCroppedTiles(mapFile);
 
@@ -39,6 +40,7 @@ public class TrainingDataUtil {
         try {
             Map<String, Object> collections = Util.loadCollections(cacheDir, agencyID, progressObserver);
             tripCollection = (TripCollection)collections.get("trips");
+            routeCollection = (RouteCollection)collections.get("routes");
             shapeCollection = (ShapeCollection)collections.get("shapes");
         } catch(Exception e) {
             Debug.error("* can't load agency data for: " + agencyID);
@@ -46,7 +48,7 @@ public class TrainingDataUtil {
             return;
         }
 
-        DayLogSlicer dls = new DayLogSlicer(tripCollection, lines);
+        DayLogSlicer dls = new DayLogSlicer(tripCollection, routeCollection, lines);
         List<TripReportData> tdList = dls.getTripReportDataList();
         Map<String, List<GPSData>> map = dls.getMap();
         int tileIndex = 0;


### PR DESCRIPTION
- Rename "name" to "headsign" in cases where it actually is the headsign. I have flip-flopped on this in past PRs but believe we're moving towards consistency
- Add RouteCollection is parameter to DayLogSlicer, and have it provide route_name when trip_headsign is null. This required updating TrainingDataUtil.java, something I'm not familiar with and don't know how to test. But ultimately it just replaces a string value with another string value
- Use [ua_parser](https://github.com/ua-parser/uap-java) to parse useragent, os & device from agent field
- Add agent, os, device, uuid & vehicleID to GRaaS report

Potential issues 
- Currently user agent parsing is occurring within TripReportData.java. There is a good argument for creating a file specifically for parsing user agents. That work could be done in this PR, or once we have a second use case for these attributes. Left a TODO comment with this info.
- New attributes listed on graphicreport (device, vehicleid, uuid tail, os, agent) could potentially overflow beyond border of chart. This PR doesn't have dynamic capabilities for adjusting or resizing text. Left a TODO comment with this info.

Example report:
![Screen Shot 2022-01-13 at 1 14 16 PM](https://user-images.githubusercontent.com/3301353/149410200-7f8fb884-1d9c-47cd-b85e-a1aea91d613b.png)
