### PR TITLE
dotsize reflects repeat gps updates

### DIFF
--- a/gtfu/src/main/java/gtfu/GPSData.java
+++ b/gtfu/src/main/java/gtfu/GPSData.java
@@ -4,11 +4,13 @@ public class GPSData {
     public long millis;
     public float lat;
     public float lon;
+    public int count;
 
-    public GPSData(long millis, float lat, float lon) {
+    public GPSData(long millis, float lat, float lon, int count) {
         this.millis = millis;
         this.lat = lat;
         this.lon = lon;
+        this.count = count;
     }
 
     public String toString() {
@@ -17,5 +19,9 @@ public class GPSData {
 
     public String toCSVLine() {
         return String.format("%d,%f,%f", millis / 1000, lat, lon);
+    }
+
+    public void increment() {
+        count++;
     }
 }

--- a/gtfu/src/main/java/gtfu/GPSData.java
+++ b/gtfu/src/main/java/gtfu/GPSData.java
@@ -6,11 +6,11 @@ public class GPSData {
     public float lon;
     public int count;
 
-    public GPSData(long millis, float lat, float lon, int count) {
+    public GPSData(long millis, float lat, float lon) {
         this.millis = millis;
         this.lat = lat;
         this.lon = lon;
-        this.count = count;
+        this.count = 1;
     }
 
     public String toString() {

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -11,7 +11,6 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
-
 import java.awt.geom.Path2D;
 
 import javax.imageio.ImageIO;
@@ -56,6 +55,8 @@ public class GraphicReport {
         "vehicle-id", "timestamp", "lat", "long", "trip-id", "agency-id", "uuid", "agent"
     };
     private static final int SCALE = 2;
+    private static final float DOT_SIZE = 1.75f * SCALE;
+    private static final int DOT_SIZE_MULTIPLIER = 5;
     private static final int CANVAS_WIDTH = 1200 * SCALE;
     private static final int TILE_SIZE = 200 * SCALE;
     private static final int MIN_HEIGHT = 40 * SCALE;
@@ -64,11 +65,11 @@ public class GraphicReport {
     private TripCollection tripCollection;
     private RouteCollection routeCollection;
     private ShapeCollection shapeCollection;
-    private Map<String, List<GPSData>> map;
+    private Map<String, Map<String, GPSData>> gpsMap;
     private List<TripReportData> tdList;
     private Map<String, TripReportData> tdMap;
     private BufferedImage img;
-    private Ellipse2D.Float dot = new Ellipse2D.Float(0, 0, 1.75f * SCALE, 1.75f * SCALE);
+    private Ellipse2D.Float dot = new Ellipse2D.Float(0, 0, DOT_SIZE, DOT_SIZE);
     private Rectangle2D clipRect = new Rectangle2D.Float();
     private Font font;
     private Font smallFont;
@@ -131,7 +132,7 @@ public class GraphicReport {
 
             List<String> lines = logs.get(key);
             DayLogSlicer dls = new DayLogSlicer(tripCollection, routeCollection, lines);
-            map = dls.getMap();
+            gpsMap = dls.getMap();
             tdList = dls.getTripReportDataList();
             tdMap = dls.getTripReportDataMap();
             int startSecond = dls.getStartSecond();
@@ -251,7 +252,7 @@ public class GraphicReport {
             if (Math.random() < prob) {
                 String id = t.getID();
 
-                if (map.get(id) == null) {
+                if (gpsMap.get(id) == null) {
                     int start = t.getStartTime() * 1000;
                     int t1 = t.getTimeAt(0);
                     int t2 = t.getTimeAt(t.getStopSize() - 1);
@@ -261,19 +262,19 @@ public class GraphicReport {
                     tdList.add(td);
                     tdMap.put(id, td);
 
-                    List<GPSData> l = new ArrayList<GPSData>();
+                    Map<String, GPSData> latLongMap = new HashMap();
                     long midnight = Time.getMidnightTimestamp();
                     int step = 5 * 60 * 1000;
                     int offset = 0;
 
                     while (offset < duration) {
                         ShapePoint p = t.getLocation(offset);
-
-                        l.add(new GPSData(midnight + start + offset, p.lat, p.lon));
+                        String latLon = String.valueOf(p.lat) + String.valueOf(p.lon);
+                        latLongMap.put(latLon, new GPSData(midnight + start + offset, p.lat, p.lon, 1));
                         offset += step;
                     }
 
-                    map.put(id, l);
+                    gpsMap.put(id,latLongMap);
                 }
             }
         }
@@ -362,13 +363,13 @@ public class GraphicReport {
         g.setColor(ACCENT);
         yoff = 4 * SCALE;
 
-        for (String id : map.keySet()) {
-            List<GPSData> list = map.get(id);
+        for (String id : gpsMap.keySet()) {
+            Map<String, GPSData> latLonMap = gpsMap.get(id);
             TripReportData td = tdMap.get(id);
             if (td == null) continue;
 
-            for (GPSData p : list) {
-                int dayMillis = Time.getDayOffsetMillis(p.millis);
+            for (String latLon : latLonMap.keySet()) {
+                int dayMillis = Time.getDayOffsetMillis(latLonMap.get(latLon).millis);
                 int x = getDayFraction(bw, dayMillis);
 
                 g.drawLine(start + x, td.y + yoff, start + x, td.y + td.height - yoff);
@@ -430,8 +431,6 @@ public class GraphicReport {
 
             g.translate(x + inset, y + inset);
             drawMap(g, td, length);
-
-
             g.setTransform(t);
         }
 
@@ -443,7 +442,7 @@ public class GraphicReport {
 
         Area area = new Area();
 
-        List<GPSData> gpsl = map.get(td.id);
+        Map<String, GPSData> latLonMap = gpsMap.get(td.id);
         //Debug.log("- gpsl.size(): " + gpsl.size());
 
         Trip trip = tripCollection.get(td.id);
@@ -457,8 +456,8 @@ public class GraphicReport {
             area.update(sp);
         }
 
-        for (GPSData d : gpsl) {
-            area.update(d.lat, d.lon);
+        for (String latLon : latLonMap.keySet()) {
+            area.update(latLonMap.get(latLon).lat, latLonMap.get(latLon).lon);
         }
 
         //g.setClip(0, 0, length, length);
@@ -483,16 +482,17 @@ public class GraphicReport {
         }
 
         g.draw(path);
-
-
         g.setStroke(savedStroke);
         g.setColor(ACCENT);
 
         // Draw vehicle location ---
-        for (int i=0; i<gpsl.size(); i++) {
-            GPSData d = gpsl.get(i);
-            Point p = latLongToScreenXY(area, d.lat, d.lon, length, length);
+        for (String latLon : latLonMap.keySet()) {
+            Point p = latLongToScreenXY(area, latLonMap.get(latLon).lat, latLonMap.get(latLon).lon, length, length);
 
+            Integer count = latLonMap.get(latLon).count;
+            float scaledDotSize = DOT_SIZE * (1 + (count - 1) / DOT_SIZE_MULTIPLIER);
+            dot.width = scaledDotSize;
+            dot.height = scaledDotSize;
             //g.fillOval(p.x - 1, p.y - 1, 2, 2);
             dot.x = p.x - dot.width / 2;
             dot.y = p.y - dot.width / 2;

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -12,7 +12,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.Path2D;
-
 import javax.imageio.ImageIO;
 
 import java.io.ByteArrayOutputStream;

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -58,7 +58,7 @@ public class GraphicReport {
     private static final float DOT_SIZE = 1.75f * SCALE;
     private static final int DOT_SIZE_MULTIPLIER = 5;
     private static final int CANVAS_WIDTH = 1200 * SCALE;
-    private static final int TILE_SIZE = 200 * SCALE;
+    private static final int TILE_SIZE = 300 * SCALE;
     private static final int MIN_HEIGHT = 40 * SCALE;
     private static final int ROW_HEIGHT = 30 * SCALE;
 

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -55,7 +55,7 @@ public class GraphicReport {
     };
     private static final int SCALE = 2;
     private static final float DOT_SIZE = 1.75f * SCALE;
-    private static final int DOT_SIZE_MULTIPLIER = 5;
+    private static final int DOT_SIZE_MULTIPLIER = 8;
     private static final int CANVAS_WIDTH = 1200 * SCALE;
     private static final int TILE_SIZE = 300 * SCALE;
     private static final int MIN_HEIGHT = 40 * SCALE;
@@ -261,7 +261,7 @@ public class GraphicReport {
                     tdList.add(td);
                     tdMap.put(id, td);
 
-                    Map<String, GPSData> latLongMap = new HashMap();
+                    Map<String, GPSData> latLonMap = new HashMap();
                     long midnight = Time.getMidnightTimestamp();
                     int step = 5 * 60 * 1000;
                     int offset = 0;
@@ -269,11 +269,11 @@ public class GraphicReport {
                     while (offset < duration) {
                         ShapePoint p = t.getLocation(offset);
                         String latLon = String.valueOf(p.lat) + String.valueOf(p.lon);
-                        latLongMap.put(latLon, new GPSData(midnight + start + offset, p.lat, p.lon, 1));
+                        latLonMap.put(latLon, new GPSData(midnight + start + offset, p.lat, p.lon));
                         offset += step;
                     }
 
-                    gpsMap.put(id,latLongMap);
+                    gpsMap.put(id,latLonMap);
                 }
             }
         }
@@ -427,7 +427,6 @@ public class GraphicReport {
             g.drawString(s, x + (TILE_SIZE - sw) / 2, y);
 
             AffineTransform t = g.getTransform();
-
             g.translate(x + inset, y + inset);
             drawMap(g, td, length);
             g.setTransform(t);

--- a/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
+++ b/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
@@ -13,6 +13,7 @@ import gtfu.RouteCollection;
 import gtfu.Route;
 import gtfu.TripReportData;
 import gtfu.Debug;
+import gtfu.Util;
 
 public class DayLogSlicer {
     private Map<String, Map<String, GPSData>> gpsMap;
@@ -23,7 +24,7 @@ public class DayLogSlicer {
     private Map<String, TripReportData> tdMap;
     private int startSecond;
 
-  public DayLogSlicer(TripCollection tripCollection, RouteCollection routeCollection, List<String> lines) {
+    public DayLogSlicer(TripCollection tripCollection, RouteCollection routeCollection, List<String> lines) {
         gpsMap = new HashMap();
         uuidMap = new HashMap();
         agentMap = new HashMap();
@@ -85,12 +86,12 @@ public class DayLogSlicer {
             String name = trip.getHeadsign();
 
             // Use routeName if Headsign is null
-            if (name == null || name == "") {
+            if (Util.isEmpty(name)) {
                 String route_id = trip.getRouteID();
                 Route route = routeCollection.get(route_id);
                 name = route.getName();
                 // Use tripID if routeName is null
-                if (name == null || name == "") {
+                if (Util.isEmpty(name)) {
                     name = id;
                 }
             }

--- a/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
+++ b/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
@@ -59,18 +59,18 @@ public class DayLogSlicer {
             agentMap.put(tripID,agent);
 
             String latLon = String.valueOf(lat) + String.valueOf(lon);
+            // If there is no LatLonMap for this trip, add it.
             if(gpsMap.get(tripID) == null){
-                Map<String, GPSData> latLongMap = new HashMap();
-                latLongMap.put(latLon, new GPSData(seconds * 1000l, lat, lon, 1));
-                gpsMap.put(tripID,latLongMap);
+                Map<String, GPSData> latLonMap = new HashMap();
+                gpsMap.put(tripID,latLonMap);
             }
-            else {
-                if (gpsMap.get(tripID).get(latLon) == null) {
-                    gpsMap.get(tripID).put(latLon, new GPSData(seconds * 1000l, lat, lon, 1));
-                }
-                else{
-                    gpsMap.get(tripID).get(latLon).increment();
-                }
+            // If there is no existing GPSData for this latLon value, add it
+            if (gpsMap.get(tripID).get(latLon) == null) {
+                gpsMap.get(tripID).put(latLon, new GPSData(seconds * 1000l, lat, lon));
+            }
+            // If there is already a GPSData for this latLon value, increment the count
+            else{
+                gpsMap.get(tripID).get(latLon).increment();
             }
         }
 

--- a/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
+++ b/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
@@ -84,12 +84,13 @@ public class DayLogSlicer {
             }
             String name = trip.getHeadsign();
 
-            // Default to trip_headsign. Use routeName if null
-            if (name == null) {
+            // Use routeName if Headsign is null
+            if (name == null || name == "") {
                 String route_id = trip.getRouteID();
                 Route route = routeCollection.get(route_id);
                 name = route.getName();
-                if (name == null) {
+                // Use tripID if routeName is null
+                if (name == null || name == "") {
                     name = id;
                 }
             }

--- a/gtfu/src/main/java/gtfu/tools/TrainingDataUtil.java
+++ b/gtfu/src/main/java/gtfu/tools/TrainingDataUtil.java
@@ -50,16 +50,16 @@ public class TrainingDataUtil {
 
         DayLogSlicer dls = new DayLogSlicer(tripCollection, routeCollection, lines);
         List<TripReportData> tdList = dls.getTripReportDataList();
-        Map<String, List<GPSData>> map = dls.getMap();
+        Map<String, Map<String, GPSData>> gpsMap = dls.getMap();
         int tileIndex = 0;
 
         for (TripReportData td : tdList) {
-            List<GPSData> list = map.get(td.id);
+            Map<String, GPSData> latLonMap = gpsMap.get(td.id);
 
-            String folderName = makeFolder(outputDir, list.get(0).millis, agencyID);
+            String folderName = makeFolder(outputDir, latLonMap.get(latLonMap.keySet().stream().findFirst()).millis, agencyID);
             Debug.log("- folderName: " + folderName);
 
-            writePositionsToFile(folderName + "/updates.txt", list);
+            writePositionsToFile(folderName + "/updates.txt", latLonMap);
             writeStringToFile(folderName + "/metadata.txt", td.id);
 
             Trip trip = tripCollection.get(td.id);
@@ -79,13 +79,13 @@ public class TrainingDataUtil {
         }
     }
 
-    private static void writePositionsToFile(String path, List<GPSData> list) throws Exception {
+    private static void writePositionsToFile(String path, Map<String,GPSData> latLonMap) throws Exception {
         try (
             FileOutputStream fos = new FileOutputStream(path);
             PrintWriter out = new PrintWriter(fos)
         ) {
-            for (GPSData gps : list) {
-                out.println(gps.toCSVLine());
+            for (String latLon : latLonMap.keySet()) {
+                out.println(latLonMap.get(latLon).toCSVLine());
             }
         }
     }


### PR DESCRIPTION
- GPS update dot size increases by 20% of original size for each repeat update sharing same exact latlong. Did this by replacing List<GPSData> with Map<String,GPSData>, which maps each latLong combo with the corresponding GPSData. Increment when already exists.
- Fixes bug where DesertRoadrunner trip names weren't appearing

Potential Issues:
- TrainingDataUtil.java changes remain untested. Will seek guidance on how to test.