### PR TITLE
Update gcloud auth method

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -31,11 +31,12 @@ jobs:
         env:
           PR_TEST_ID_ECDSA: ${{ secrets.PR_TEST_ID_ECDSA }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/auth@v0
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          # Google recommends using a Workload Identify Federation instead of using the service account key json file
+          # but this method is continuing to be supported. More info: https://github.com/google-github-actions/auth#setup
+          service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
+          credentials_json: ${{ secrets.GCP_SA_KEY_JSON }}
       - name: Run Python unit tests
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -18,8 +18,8 @@ jobs:
         uses: google-github-actions/auth@v0
         with:
           service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.GCP_SA_KEY_JSON }}
+          # export_default_credentials: true
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -1,8 +1,8 @@
 name: Send GRaaS Report
 # ~9:18PM pacific time, daily:
-on:
- schedule:
-    - cron: '0 5 * * *'
+on: [push]
+ # schedule:
+ #    - cron: '0 5 * * *'
 jobs:
   Send-email:
     runs-on: ubuntu-latest

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -1,8 +1,8 @@
 name: Send GRaaS Report
 # ~9:18PM pacific time, daily:
-on:
- schedule:
-    - cron: '0 5 * * *'
+on: [push]
+ # schedule:
+ #    - cron: '0 5 * * *'
 jobs:
   Send-email:
     runs-on: ubuntu-latest
@@ -15,10 +15,10 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
+          credentials_json: {{ secrets.GCP_SA_KEY_JSON }}
           export_default_credentials: true
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -18,8 +18,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
-          credentials_json: {{ fromJson(secrets.GCP_SA_KEY_JSON) }}
-          export_default_credentials: true
+          # credentials_json: {{ secrets.GCP_SA_KEY_JSON) }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -18,8 +18,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_email: 'lat-long-prototype@appspot.gserviceaccount.com'
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          # service_account_key: {{ secrets.GCP_SA_KEY_JSON) }}
+          service_account_key: {{ secrets.GCP_SA_KEY_JSON) }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -1,8 +1,8 @@
 name: Send GRaaS Report
 # ~9:18PM pacific time, daily:
-on: [push]
- # schedule:
- #    - cron: '0 5 * * *'
+on:
+ schedule:
+    - cron: '0 5 * * *'
 jobs:
   Send-email:
     runs-on: ubuntu-latest
@@ -17,9 +17,10 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/auth@v0
         with:
+          # Google recommends using a Workload Identify Federation instead of using the service account key json file
+          # but this method is continuing to be supported. More info: https://github.com/google-github-actions/auth#setup
           service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
           credentials_json: ${{ secrets.GCP_SA_KEY_JSON }}
-          # export_default_credentials: true
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -1,8 +1,8 @@
 name: Send GRaaS Report
 # ~9:18PM pacific time, daily:
-on: [push]
- # schedule:
- #    - cron: '0 5 * * *'
+on:
+ schedule:
+    - cron: '0 5 * * *'
 jobs:
   Send-email:
     runs-on: ubuntu-latest

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -14,11 +14,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
         with:
-          service_account_email: 'lat-long-prototype@appspot.gserviceaccount.com'
-          service_account_key: {{ secrets.GCP_SA_KEY_JSON) }}
+          service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
+          credentials_json: {{ secrets.GCP_SA_KEY_JSON) }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -1,8 +1,8 @@
 name: Send GRaaS Report
 # ~9:18PM pacific time, daily:
-on: [push]
- # schedule:
- #    - cron: '0 5 * * *'
+on:
+ schedule:
+    - cron: '0 5 * * *'
 jobs:
   Send-email:
     runs-on: ubuntu-latest
@@ -14,11 +14,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Authenticate to Google Cloud
+      - name: Set up Cloud SDK
         uses: google-github-actions/auth@v0
         with:
           service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
-          credentials_json: {{ secrets.GCP_SA_KEY_JSON) }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
-          credentials_json: {{ toJson(secrets.GCP_SA_KEY_JSON) }}
+          credentials_json: {{ fromJson(secrets.GCP_SA_KEY_JSON) }}
           export_default_credentials: true
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
           # credentials_json: {{ secrets.GCP_SA_KEY_JSON) }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -1,5 +1,5 @@
 name: Send GRaaS Report
-# ~9:18PM pacific time, daily:
+#~9:18PM pacific time, daily:
 on: [push]
  # schedule:
  #    - cron: '0 5 * * *'

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -17,9 +17,9 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
+          service_account_email: 'lat-long-prototype@appspot.gserviceaccount.com'
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-          # credentials_json: {{ secrets.GCP_SA_KEY_JSON) }}
+          # service_account_key: {{ secrets.GCP_SA_KEY_JSON) }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/send-graas-report.yaml
+++ b/.github/workflows/send-graas-report.yaml
@@ -1,5 +1,5 @@
 name: Send GRaaS Report
-#~9:18PM pacific time, daily:
+# ~9:18PM pacific time, daily:
 on: [push]
  # schedule:
  #    - cron: '0 5 * * *'
@@ -18,7 +18,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
-          credentials_json: {{ secrets.GCP_SA_KEY_JSON }}
+          credentials_json: {{ toJson(secrets.GCP_SA_KEY_JSON) }}
           export_default_credentials: true
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/gtfu/src/main/resources/conf/recipients.json
+++ b/gtfu/src/main/resources/conf/recipients.json
@@ -4,6 +4,9 @@
         "kay.neuenhofen@dot.ca.gov"
       ],
 	"graas_report": [
-        "scott.owades@dot.ca.gov"
+        "scott.owades@dot.ca.gov",
+        "kay.neuenhofen@dot.ca.gov",
+        "ali.attari@rebelgroup.com",
+        "lauren.gilbert@rebelgroup.com"
       ]
 }

--- a/gtfu/src/main/resources/conf/recipients.json
+++ b/gtfu/src/main/resources/conf/recipients.json
@@ -4,9 +4,6 @@
         "kay.neuenhofen@dot.ca.gov"
       ],
 	"graas_report": [
-        "scott.owades@dot.ca.gov",
-        "kay.neuenhofen@dot.ca.gov",
-        "ali.attari@rebelgroup.com",
-        "lauren.gilbert@rebelgroup.com"
+        "scott.owades@dot.ca.gov"
       ]
 }


### PR DESCRIPTION
The current github action <> gcloud auth method is about to be deprecated. The replacement method, storing the service account key json file as a github secret, is supported by google, though it's [not preferred](https://github.com/google-github-actions/auth#setup).

The more robust solution would be setting up a Workload Identify Federation - which would grant a specified level of access to github, and would not be valid except for when github processes are running. I'm open to going with this approach instead - we will need to update some IAM settings in gcloud as a first step.