### PR TITLE
Bugfix: filter short trips from GRaaS report

### DIFF
--- a/gtfu/src/main/java/gtfu/GPSData.java
+++ b/gtfu/src/main/java/gtfu/GPSData.java
@@ -26,4 +26,12 @@ public class GPSData {
     public void increment() {
         count++;
     }
+
+    public Double getSecsSinceLastUpdateDouble() {
+        return Double.valueOf(secsSinceLastUpdate);
+    }
+
+    public Double getMillisDouble() {
+        return Double.valueOf(millis);
+    }
 }

--- a/gtfu/src/main/java/gtfu/GPSData.java
+++ b/gtfu/src/main/java/gtfu/GPSData.java
@@ -27,11 +27,11 @@ public class GPSData {
         count++;
     }
 
-    public Double getSecsSinceLastUpdateDouble() {
+    public Double getSecsSinceLastUpdateAsDouble() {
         return Double.valueOf(secsSinceLastUpdate);
     }
 
-    public Double getMillisDouble() {
+    public Double getMillisAsDouble() {
         return Double.valueOf(millis);
     }
 }

--- a/gtfu/src/main/java/gtfu/GPSData.java
+++ b/gtfu/src/main/java/gtfu/GPSData.java
@@ -1,6 +1,6 @@
 package gtfu;
 
-public class GPSData implements StatValue {
+public class GPSData {
     public long millis;
     public int secsSinceLastUpdate;
     public float lat;
@@ -25,13 +25,5 @@ public class GPSData implements StatValue {
 
     public void increment() {
         count++;
-    }
-
-    // For use as a StatValue:
-    public Double getValue() {
-        if(secsSinceLastUpdate > 0) {
-            Double secsSinceLastUpdateDouble = Double.valueOf(secsSinceLastUpdate);
-            return secsSinceLastUpdateDouble;
-        } else return null;
     }
 }

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -274,7 +274,18 @@ public class GraphicReport {
                     }
 
                     gpsMap.put(id,latLonMap);
-                    TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "test", "test", "test", new Stats(gpsMap.get(id).values()));
+
+                    List<Double> updateFreqList = new ArrayList<>();
+                    List<Double> updateTimeList = new ArrayList<>();
+
+                    for (GPSData gpsData : gpsMap.get(id).values()) {
+                        if(gpsData.secsSinceLastUpdate > 0) {
+                            Double secsSinceLastUpdateDouble = Double.valueOf(gpsData.secsSinceLastUpdate);
+                            updateFreqList.add(secsSinceLastUpdateDouble);
+                        }
+                        updateTimeList.add(Double.valueOf(gpsData.millis));
+                    }
+                    TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "test", "test", "test", new Stats(updateFreqList), new Stats(updateTimeList));
                     tdList.add(td);
                     tdMap.put(id, td);
                 }

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -276,8 +276,17 @@ public class GraphicReport {
 
                     gpsMap.put(id,latLonMap);
                     // Create lists as input to Stats
-                    List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateAsDouble).filter(secs -> secs > 0).collect(Collectors.toList());
-                    List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisAsDouble).collect(Collectors.toList());
+                    List<Double> updateFreqList = new ArrayList<>();
+                    List<Double> updateMillisList = new ArrayList<>();
+
+                    for (GPSData gpsData : gpsMap.get(id).values()) {
+                        Double secsSinceLastUpdateDouble = gpsData.getSecsSinceLastUpdateAsDouble();
+
+                        if(secsSinceLastUpdateDouble > 0) {
+                            updateFreqList.add(secsSinceLastUpdateDouble);
+                        }
+                        updateMillisList.add(gpsData.getMillisAsDouble());
+                    }
 
                     TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "test", "test", "test", new Stats(updateFreqList), new Stats(updateMillisList));
                     tdList.add(td);

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -279,7 +279,7 @@ public class GraphicReport {
                     List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateDouble).filter(secs -> secs > 0).collect(Collectors.toList());
                     List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisDouble).collect(Collectors.toList());
 
-                    TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "test", "test", "test", new Stats(updateFreqList), new Stats(updateTimeList));
+                    TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "test", "test", "test", new Stats(updateFreqList), new Stats(updateMillisList));
                     tdList.add(td);
                     tdMap.put(id, td);
                 }

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import gtfu.tools.DayLogSlicer;
 import gtfu.tools.DB;
@@ -274,17 +275,10 @@ public class GraphicReport {
                     }
 
                     gpsMap.put(id,latLonMap);
+                    // Create lists as input to Stats
+                    List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateDouble).filter(secs -> secs > 0).collect(Collectors.toList());
+                    List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisDouble).collect(Collectors.toList());
 
-                    List<Double> updateFreqList = new ArrayList<>();
-                    List<Double> updateTimeList = new ArrayList<>();
-
-                    for (GPSData gpsData : gpsMap.get(id).values()) {
-                        if(gpsData.secsSinceLastUpdate > 0) {
-                            Double secsSinceLastUpdateDouble = Double.valueOf(gpsData.secsSinceLastUpdate);
-                            updateFreqList.add(secsSinceLastUpdateDouble);
-                        }
-                        updateTimeList.add(Double.valueOf(gpsData.millis));
-                    }
                     TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "test", "test", "test", new Stats(updateFreqList), new Stats(updateTimeList));
                     tdList.add(td);
                     tdMap.put(id, td);

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -276,8 +276,8 @@ public class GraphicReport {
 
                     gpsMap.put(id,latLonMap);
                     // Create lists as input to Stats
-                    List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateDouble).filter(secs -> secs > 0).collect(Collectors.toList());
-                    List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisDouble).collect(Collectors.toList());
+                    List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateAsDouble).filter(secs -> secs > 0).collect(Collectors.toList());
+                    List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisAsDouble).collect(Collectors.toList());
 
                     TripReportData td = new TripReportData(id, t.getHeadsign(), start, duration, "test", "test", "test", new Stats(updateFreqList), new Stats(updateMillisList));
                     tdList.add(td);

--- a/gtfu/src/main/java/gtfu/Stats.java
+++ b/gtfu/src/main/java/gtfu/Stats.java
@@ -3,6 +3,8 @@ package gtfu;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Stats {
 
@@ -11,22 +13,20 @@ public class Stats {
     private double max = Double.MIN_VALUE;
 
 
-    public Stats(Collection<? extends StatValue> c) {
+    public Stats(List<Double> l) {
         double total = 0;
         int count = 0;
 
-        for (StatValue v : c) {
-            Double value = v.getValue();
-            if (value == null) continue;
+        for (Double d : l) {
             count++;
-            total += value;
+            total += d;
 
-            if (value < min) {
-                min = value;
+            if (d < min) {
+                min = d;
             }
 
-            if (value > max) {
-                max = value;
+            if (d > max) {
+                max = d;
             }
         }
         if (count > 0) avg = total / count;
@@ -43,8 +43,4 @@ public class Stats {
     public double getMax() {
         return max;
     }
-}
-
-interface StatValue {
-    public Double getValue();
 }

--- a/gtfu/src/main/java/gtfu/TripReportData.java
+++ b/gtfu/src/main/java/gtfu/TripReportData.java
@@ -113,11 +113,11 @@ public class TripReportData implements Comparable<TripReportData> {
     }
 
     public double getDurationMillis() {
-        return (updateTimeStats.getMax() - updateTimeStats.getMin());
+        return updateTimeStats.getMax() - updateTimeStats.getMin();
     }
 
     public int getDurationMins() {
-        return (int) getDurationMillis() / 60 / 1000;
+        return (int) getDurationMillis() / Time.MILLIS_PER_MINUTE;
     }
 
     public boolean overlaps(TripReportData td) {

--- a/gtfu/src/main/java/gtfu/TripReportData.java
+++ b/gtfu/src/main/java/gtfu/TripReportData.java
@@ -18,9 +18,10 @@ public class TripReportData implements Comparable<TripReportData> {
     String vehicleId;
     Client deviceClient;
     Parser uaParser = new Parser();
-    public Stats stats;
+    public Stats updateFreqStats;
+    public Stats updateTimeStats;
 
-    public TripReportData(String id, String name, int start, int duration, String uuid, String agent, String vehicleId, Stats stats) {
+    public TripReportData(String id, String name, int start, int duration, String uuid, String agent, String vehicleId, Stats updateFreqStats, Stats updateTimeStats) {
         this.id = id;
         this.name = name;
         this.start = start;
@@ -30,7 +31,8 @@ public class TripReportData implements Comparable<TripReportData> {
         this.vehicleId = vehicleId;
         // TODO: Create new file for getting deviceClient info
         this.deviceClient = uaParser.parse(agent);
-        this.stats = stats;
+        this.updateFreqStats = updateFreqStats;
+        this.updateTimeStats = updateTimeStats;
     }
 
     public int compareTo(TripReportData o) {
@@ -99,16 +101,23 @@ public class TripReportData implements Comparable<TripReportData> {
     }
 
     public String getAvgUpdateInterval() {
-        return String.format("%.2f",stats.getAvg());
+        return String.format("%.2f",updateFreqStats.getAvg());
     }
 
     public String getMaxUpdateInterval() {
-        return String.format("%.0f",stats.getMax());
+        return String.format("%.0f",updateFreqStats.getMax());
     }
 
     public String getMinUpdateInterval() {
-        return String.format("%.0f",stats.getMin());
+        return String.format("%.0f",updateFreqStats.getMin());
+    }
 
+    public double getDurationSecs() {
+        return updateTimeStats.getMax() - updateTimeStats.getMin();
+    }
+
+    public int getDurationMins() {
+        return (int) getDurationSecs()/60;
     }
 
     public boolean overlaps(TripReportData td) {

--- a/gtfu/src/main/java/gtfu/TripReportData.java
+++ b/gtfu/src/main/java/gtfu/TripReportData.java
@@ -112,12 +112,12 @@ public class TripReportData implements Comparable<TripReportData> {
         return String.format("%.0f",updateFreqStats.getMin());
     }
 
-    public double getDurationSecs() {
-        return updateTimeStats.getMax() - updateTimeStats.getMin();
+    public double getDurationMillis() {
+        return (updateTimeStats.getMax() - updateTimeStats.getMin());
     }
 
     public int getDurationMins() {
-        return (int) getDurationSecs()/60;
+        return (int) getDurationMillis() / 60 / 1000;
     }
 
     public boolean overlaps(TripReportData td) {

--- a/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
+++ b/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
@@ -126,8 +126,17 @@ public class DayLogSlicer {
             // Debug.log("++   durationMins: " + durationMins);
 
             // Create lists as input to Stats
-            List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateAsDouble).filter(secs -> secs > 0).collect(Collectors.toList());
-            List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisAsDouble).collect(Collectors.toList());
+            List<Double> updateFreqList = new ArrayList<>();
+            List<Double> updateMillisList = new ArrayList<>();
+
+            for (GPSData gpsData : gpsMap.get(id).values()) {
+                Double secsSinceLastUpdateDouble = gpsData.getSecsSinceLastUpdateAsDouble();
+
+                if(secsSinceLastUpdateDouble > 0) {
+                    updateFreqList.add(secsSinceLastUpdateDouble);
+                }
+                updateMillisList.add(gpsData.getMillisAsDouble());
+            }
 
             TripReportData td = new TripReportData(id, name, start, duration, uuidMap.get(id), agentMap.get(id), vehicleIdMap.get(id), new Stats(updateFreqList), new Stats(updateMillisList));
             int tripDuration = td.getDurationMins();

--- a/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
+++ b/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
@@ -126,8 +126,8 @@ public class DayLogSlicer {
             // Debug.log("++   durationMins: " + durationMins);
 
             // Create lists as input to Stats
-            List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateDouble).filter(secs -> secs > 0).collect(Collectors.toList());
-            List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisDouble).collect(Collectors.toList());
+            List<Double> updateFreqList = gpsMap.get(id).values().stream().map(GPSData::getSecsSinceLastUpdateAsDouble).filter(secs -> secs > 0).collect(Collectors.toList());
+            List<Double> updateMillisList = gpsMap.get(id).values().stream().map(GPSData::getMillisAsDouble).collect(Collectors.toList());
 
             TripReportData td = new TripReportData(id, name, start, duration, uuidMap.get(id), agentMap.get(id), vehicleIdMap.get(id), new Stats(updateFreqList), new Stats(updateMillisList));
             int tripDuration = td.getDurationMins();

--- a/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
+++ b/gtfu/src/main/java/gtfu/tools/DayLogSlicer.java
@@ -122,9 +122,25 @@ public class DayLogSlicer {
             // Debug.log("++   end: " + Time.getHMForMillis(start + duration));
             // Debug.log("++   duration: " + Time.getHMForMillis(start + duration));
             // Debug.log("++   durationMins: " + durationMins);
-            // Filter out trips shorter than 15 min
-            if (durationMins >= 15) {
-                TripReportData td = new TripReportData(id, name, start, duration, uuidMap.get(id), agentMap.get(id), vehicleIdMap.get(id), new Stats(gpsMap.get(id).values()));
+
+
+            List<Double> updateFreqList = new ArrayList<>();
+            List<Double> updateTimeList = new ArrayList<>();
+
+            for (GPSData gpsData : gpsMap.get(id).values()) {
+
+                if(gpsData.secsSinceLastUpdate > 0) {
+                    Double secsSinceLastUpdateDouble = Double.valueOf(gpsData.secsSinceLastUpdate);
+                    updateFreqList.add(secsSinceLastUpdateDouble);
+                }
+
+                updateTimeList.add(Double.valueOf(gpsData.millis));
+            }
+
+            TripReportData td = new TripReportData(id, name, start, duration, uuidMap.get(id), agentMap.get(id), vehicleIdMap.get(id), new Stats(updateFreqList), new Stats(updateTimeList));
+
+            // Filter out trips that last less than 10 minutes
+            if (td.getDurationMins() >= 10) {
                 tdList.add(td);
                 tdMap.put(id, td);
             }

--- a/gtfu/src/test/java/gtfu/test/BBSAgentTest.java
+++ b/gtfu/src/test/java/gtfu/test/BBSAgentTest.java
@@ -48,6 +48,7 @@ class BBSAgentTest {
                 "",
                 agent,
                 "",
+                null,
                 null
             );
 


### PR DESCRIPTION
This is more cleanup of bugs created early in my GRaaS dev. I had filtered out trips shorter than 15min, but it turns out I had filtered based on schedule rather than GRaaS app sessions. This change removes the faulty logic, and builds new logic to filter out short GRaaS app trips - currently set to a 1min threshold but can be changed easily.

In order to do this, I update the Stats class to accept a list of doubles - and then generate that list before creating each new Stats class instance. This way, it can calculate min and max on two different values within GPSData.

A simpler approach could be to filter out trips with fewer than X location updates (regardless of duration). We could just count the number of items in the map and filter based on that. In my opinion, despite being more complicated, filtering based on duration is more intuitive.

In testing, this approach created identical GRaaS reports to what we are seeing on the main branch, with the very short trips filtered out. Example of two trips filtered out: note the trip with "000000000" is the result of having only one GPS point - and so that bug is addressed with this PR as well.
![Screen Shot 2022-02-01 at 9 20 54 AM](https://user-images.githubusercontent.com/3301353/152018010-2836c0e4-e528-4c8e-b51d-108af091a43c.png)
