### PR TITLE
GRaaS report updates in preparation for interactive GRaaS report

### DIFF
--- a/gtfu/build.gradle
+++ b/gtfu/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile "com.google.cloud:google-cloud-datastore:1.2.1"
     compile "org.apache.httpcomponents.client5:httpclient5:5.1"
     compile "com.googlecode.json-simple:json-simple:1.1.1"
+    compile "com.google.cloud:google-cloud-storage:2.4.1"
     compile "com.github.ua-parser:uap-java:1.5.2"
     testImplementation "org.junit.jupiter:junit-jupiter:5.7.1"
 }

--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -26,7 +26,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Collection;
 import java.util.stream.Collectors;
 
 import gtfu.tools.DayLogSlicer;
@@ -34,7 +33,7 @@ import gtfu.tools.DB;
 import gtfu.tools.GPSLogSlicer;
 import gtfu.tools.SendGrid;
 import gtfu.tools.AgencyYML;
-import gtfu.tools.GCloudBucket;
+import gtfu.tools.GCloudStorage;
 
 import java.nio.file.Paths;
 import java.time.format.DateTimeFormatter;
@@ -79,7 +78,7 @@ public class GraphicReport {
     private Font font;
     private Font smallFont;
     private int timeRowCount;
-    private GCloudBucket gcb = new GCloudBucket();
+    private GCloudStorage gcs = new GCloudStorage();
 
     public GraphicReport(String cacheDir, String selectedDate, boolean downloadReport, String savePath, boolean sendEmail) throws Exception {
         Debug.log("GraphicReport.GraphicReport()");
@@ -221,7 +220,7 @@ public class GraphicReport {
         // converts <agency-id>-yyyy-mm-dd to <agency-id>
         String agencyID = key.substring(0, key.length() - 11);
         String path = "graas-report-archive/" + agencyID;
-        gcb.uploadObject("graas-resources", path, key, image);
+        gcs.uploadObject("graas-resources", path, key, image);
     }
 
     // Creates one report per agency per day

--- a/gtfu/src/main/java/gtfu/tools/GCloudBucket.java
+++ b/gtfu/src/main/java/gtfu/tools/GCloudBucket.java
@@ -1,0 +1,27 @@
+package gtfu.tools;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import gtfu.Debug;
+
+public class GCloudBucket {
+  private static final String PROJECT_ID = System.getenv("GCP_PROJECT_ID");
+
+  public static void uploadObject(String bucketName, String directory, String fileName, byte[] image) throws IOException {
+
+    String path = directory + "/" + fileName;
+    Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
+    BlobId blobId = BlobId.of(bucketName, path);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    storage.create(blobInfo, image);
+
+    Debug.log("File uploaded to bucket " + bucketName + " as " + path);
+
+  }
+}

--- a/gtfu/src/main/java/gtfu/tools/GCloudStorage.java
+++ b/gtfu/src/main/java/gtfu/tools/GCloudStorage.java
@@ -10,7 +10,7 @@ import java.nio.file.Paths;
 
 import gtfu.Debug;
 
-public class GCloudBucket {
+public class GCloudStorage {
   private static final String PROJECT_ID = System.getenv("GCP_PROJECT_ID");
 
   public static void uploadObject(String bucketName, String directory, String fileName, byte[] image) throws IOException {

--- a/gtfu/src/main/java/gtfu/tools/SendGrid.java
+++ b/gtfu/src/main/java/gtfu/tools/SendGrid.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.Base64;
+import java.util.Collection;
 import gtfu.Debug;
 import gtfu.HTTPUtil;
 import gtfu.HTTPClient;
@@ -12,13 +13,13 @@ public class SendGrid {
     private String[] tos;
     private String subject;
     private String body;
-    private List<byte[]> blobs;
+    private Map<String, byte[]> blobMap;
 
-    public SendGrid(String[] recipients, String emailSubject, String body, List<byte[]> images) {
+    public SendGrid(String[] recipients, String emailSubject, String body, Map<String, byte[]> images) {
         this.tos = recipients;
         this.subject = emailSubject;
         this.body = escape(body);
-        this.blobs = images;
+        this.blobMap = images;
     }
 
     private String escape(String s) {
@@ -54,8 +55,8 @@ public class SendGrid {
     private String makeAttachments() {
         StringBuffer sb = new StringBuffer();
 
-        for (int i=0; i< blobs.size(); i++) {
-            byte[] buf = blobs.get(i);
+        for (String key : blobMap.keySet()) {
+            byte[] buf = blobMap.get(key);
 
             if (sb.length() > 0) {
                 sb.append(',');
@@ -63,8 +64,8 @@ public class SendGrid {
 
             String b64 = Base64.getEncoder().encodeToString(buf);
 
-            sb.append("{\"type\": \"image/png\", \"filename\": \"report-");
-            sb.append(i);
+            sb.append("{\"type\": \"image/png\", \"filename\": \"");
+            sb.append(key);
             sb.append(".png\", \"content\": \"");
             sb.append(b64);
             sb.append("\"}");
@@ -75,8 +76,10 @@ public class SendGrid {
     public int send() {
         String attach = "";
 
-        if (blobs != null) {
+        if (blobMap.size() > 0) {
             attach = String.format(",\"attachments\": [%s]", makeAttachments());
+        } else{
+            body = "There are no files in today's GRaaS report";
         }
 
         String from = "calitp.gtfsrt@gmail.com";

--- a/gtfu/src/main/java/gtfu/tools/SendGrid.java
+++ b/gtfu/src/main/java/gtfu/tools/SendGrid.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.Base64;
-import java.util.Collection;
 import gtfu.Debug;
 import gtfu.HTTPUtil;
 import gtfu.HTTPClient;

--- a/server/tests/stress-test-config.json
+++ b/server/tests/stress-test-config.json
@@ -1,9 +1,9 @@
 {
-"use-production-server": false,
+"use-production-server": true,
 "production-server-url": "https://lat-long-prototype.wl.r.appspot.com/",
-"agency-count": 2,
-"vehicle-count": 2,
+"agency-count": 20,
+"vehicle-count": 125,
 "interval-time": 3,
-"interval-variation": 0,
-"num-repeats": 2
+"interval-variation": 1,
+"num-repeats": 120
 }


### PR DESCRIPTION
1. Accurate filenames for .png's (ie tcrta-2022-02-09)
2. Save all GRaaS reports to our storage bucket ([archive folder](https://console.cloud.google.com/storage/browser/graas-resources/graas-report-archive?project=lat-long-prototype&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false)). Overwrite if it runs multiple times in a day.
3. If there are no reports on a given day, send an email that says "No reports today". (rather than 404 error)
4. Clean up downloadReport/savePath logic, to work as follows: 
      - If savePath is given, set downloadReport to true
      - If downloadReport is set to true, use a default savePath unless one is also given
      - Email sending is no longer tied to download report, so you have option to download report AND send email. To keep a consistent UX, and given that we generally want an email to send, a parameter only needs to be passed when you DON'T want an email sent