### PR TITLE
specify content type for gcloud upload

### DIFF
--- a/gtfu/src/main/java/gtfu/GraphicReport.java
+++ b/gtfu/src/main/java/gtfu/GraphicReport.java
@@ -220,7 +220,7 @@ public class GraphicReport {
         String agencyID = key.substring(0, key.length() - 11);
         String path = "graas-report-archive/" + agencyID;
         String fileName = key + ".png";
-        gcs.uploadObject("graas-resources", path, fileName, image);
+        gcs.uploadObject("graas-resources", path, fileName, image, "image/png");
     }
 
     // Creates one report per agency per day

--- a/gtfu/src/main/java/gtfu/tools/GCloudStorage.java
+++ b/gtfu/src/main/java/gtfu/tools/GCloudStorage.java
@@ -22,7 +22,7 @@ public class GCloudStorage {
     String path = directory + "/" + fileName;
     Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
     BlobId blobId = BlobId.of(bucketName, path);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType(contentType)build();
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType(contentType).build();
     storage.create(blobInfo, file);
 
     Debug.log("File uploaded to bucket " + bucketName + " as " + path);

--- a/gtfu/src/main/java/gtfu/tools/GCloudStorage.java
+++ b/gtfu/src/main/java/gtfu/tools/GCloudStorage.java
@@ -13,13 +13,17 @@ import gtfu.Debug;
 public class GCloudStorage {
   private static final String PROJECT_ID = System.getenv("GCP_PROJECT_ID");
 
-  public static void uploadObject(String bucketName, String directory, String fileName, byte[] image) throws IOException {
+  // Upload without specifying content type will apply GCloud's default content type
+  public static void uploadObject(String bucketName, String directory, String fileName, byte[] file) throws IOException {
+    uploadObject(bucketName, directory, fileName, file, "application/octet-stream");
+  }
 
+  public static void uploadObject(String bucketName, String directory, String fileName, byte[] file, String contentType) throws IOException {
     String path = directory + "/" + fileName;
     Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_ID).build().getService();
     BlobId blobId = BlobId.of(bucketName, path);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
-    storage.create(blobInfo, image);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType(contentType)build();
+    storage.create(blobInfo, file);
 
     Debug.log("File uploaded to bucket " + bucketName + " as " + path);
 


### PR DESCRIPTION
Specifying datatype means you can view images online without downloading. compare the files in [this directory](https://console.cloud.google.com/storage/browser/graas-resources/graas-report-archive/santa-ynez-valley-transit;tab=objects?project=lat-long-prototype&prefix=&forceOnObjectsSortingFiltering=false) with different types to see what I mean.