### PR TITLE
Set up bulk assignment mode (fka "patrol mode")

### DIFF
--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -30,7 +30,7 @@ var startLon = null;
 var trips = [];
 var mode = 'vanilla';
 var sessionID = null;
-var useSimpleMode = false;
+var useBulkAssignmentMode = false;
 
 // Default filter parameters, used when agency doesn't have an agency-config.json file
 var maxMinsFromStart = 60;
@@ -400,7 +400,7 @@ function handleStartStop() {
             handleBusChoice();
         }
 
-        if(!useSimpleMode){
+        if(!useBulkAssignmentMode){
             // Only load trips again if they were last loaded more than a minute ago
             if ((millis - lastTripLoadMillis) < MILLIS_PER_MINUTE * 1) {
                 populateTripList();
@@ -497,7 +497,7 @@ function handleOkay() {
     document.cookie = `${VEHICLE_ID_COOKIE_NAME}=${vehicleID}; max-age=${MAX_VEHICLE_ID_AGE_SECS}`;
     util.log("- vehicleID: " + vehicleID);
 
-    if(!useSimpleMode){
+    if(!useBulkAssignmentMode){
         p = document.getElementById(TRIP_SELECT_DROPDOWN);
         var entry = tripIDLookup[p.value];
 
@@ -518,6 +518,10 @@ function handleOkay() {
 
     var p = document.getElementById('vehicle-id');
     p.innerHTML = "Vehicle ID: " + vehicleID;
+
+    var p = document.getElementById('trip-assignment-mode');
+    var tripAssignmentMode = (useBulkAssignmentMode ? 'bulk' : 'manual')
+    p.innerHTML = "Trip assignment mode: " + tripAssignmentMode;
 
     hideElement(ALL_DROPDOWNS);
     showElement(TRIP_STATS_ELEMENT);
@@ -859,7 +863,7 @@ function handleGPSUpdate(position) {
     data['vehicle-id'] = vehicleID;
     data['session-id'] = sessionID;
     data['pos-timestamp'] = posTimestamp;
-    data['use-simple-mode'] = useSimpleMode;
+    data['use-bulk-assignment-mode'] = useBulkAssignmentMode;
 
     if (driverName) {
         data['driver-name'] = driverName;
@@ -993,17 +997,17 @@ function gotConfigData(data, agencyID, arg) {
             isFilterByDayOfWeek = data["is-filter-by-day-of-week"];
             maxMinsFromStart = data["max-mins-from-start"];
             maxFeetFromStop = data["max-feet-from-stop"];
-            if(data["use-simple-mode"] != null){
-                useSimpleMode = data["use-simple-mode"];
+            if(data["use-bulk-assignment-mode"] != null){
+                useBulkAssignmentMode = data["use-bulk-assignment-mode"];
             }
-            // util.log(`- useSimpleMode: ${useSimpleMode}`);
+            // util.log(`- useBulkAssignmentMode: ${useBulkAssignmentMode}`);
             // util.log(`- isFilterByDayOfWeek: ${isFilterByDayOfWeek}`);
             // util.log(`- maxMinsFromStart: ${maxMinsFromStart}`);
             // util.log(`- maxFeetFromStop: ${maxFeetFromStop}`);
         }
     }
     else if (name === CONFIG_TRIP_NAMES) {
-        if (useSimpleMode){
+        if (useBulkAssignmentMode){
             configMatrix.setPresent(name, ConfigMatrix.NOT_PRESENT)
             hideElement(TRIP_SELECT_DROPDOWN);
         } else {

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -1013,7 +1013,6 @@ function gotConfigData(data, agencyID, arg) {
     } else if (name === CONFIG_VEHICLE_IDS) {
         vehicleList = data;
         populateList(BUS_SELECT_DROPDOWN, BUS_SELECT_DROPDOWN_TEXT, vehicleList);
-
     } else if (name === CONFIG_DRIVER_NAMES) {
         driverList = data;
         if (configMatrix.getPresent(CONFIG_DRIVER_NAMES) == ConfigMatrix.PRESENT) {

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -70,7 +70,7 @@ const BUS_SELECT_DROPDOWN_TEXT = "Select Bus No.";
 const DRIVER_SELECT_DROPDOWN = "driver-select";
 const DRIVER_SELECT_DROPDOWN_TEXT = "Select Driver";
 const ALL_DROPDOWNS = "config";
-const MESSAGE_TEXT_ELEMENT = "message";
+const LOADING_TEXT_ELEMENT = "loading";
 const TRIP_STATS_ELEMENT = "stats";
 
 const EARTH_RADIUS_IN_FEET = 20902231;
@@ -385,7 +385,7 @@ function handleStartStop() {
         util.log("+ delta: " + (millis - startMillis));
 
         hideElement(ALL_DROPDOWNS);
-        showElement(MESSAGE_TEXT_ELEMENT);
+        showElement(LOADING_TEXT_ELEMENT);
 
         configMatrix.setSelected(CONFIG_TRIP_NAMES, false);
         configMatrix.setSelected(CONFIG_VEHICLE_IDS, false);
@@ -408,7 +408,7 @@ function handleStartStop() {
                 populateTripList(loadTrips());
             }
         } else {
-            hideElement(MESSAGE_TEXT_ELEMENT);
+            hideElement(LOADING_TEXT_ELEMENT);
             showElement(ALL_DROPDOWNS);
         }
 
@@ -900,11 +900,8 @@ function initializeCallback(agencyData) {
 
     var key = atob(b64);
     // util.log("- key.length: " + key.length);
-    util.log("- key: " + key);
-    util.log("- b64: " + b64);
 
     const binaryDer = util.str2ab(key);
-    util.log("- binaryDer: " + binaryDer);
 
     crypto.subtle.importKey(
         "pkcs8",
@@ -946,8 +943,9 @@ function initializeCallback(agencyData) {
         });
     }).catch(function(e) {
       util.log('*** initializeCallback() error: ' + e.message);
-      changeText(MESSAGE_TEXT_ELEMENT, "QR Scan Internal Error. \r\n Please clear browser cache and then refresh the page.");
-      showElement(MESSAGE_TEXT_ELEMENT);
+      localStorage.removeItem("lat-long-pem");
+      alert("We've experienced an error and are refreshing the page. Please scan again");
+      window.location.reload();
   });
 }
 
@@ -955,7 +953,7 @@ function agencyIDCallback(response) {
     agencyID = response.agencyID;
     util.log("- agencyID: " + agencyID);
 
-    showElement(MESSAGE_TEXT_ELEMENT);
+    showElement(LOADING_TEXT_ELEMENT);
     hideElement(QR_READER_ELEMENT);
 
     if (agencyID === 'not found') {
@@ -1180,7 +1178,7 @@ function populateTripList(tripIDMap = tripIDLookup) {
 
     setupListHeader(p);
 
-    hideElement(MESSAGE_TEXT_ELEMENT);
+    hideElement(LOADING_TEXT_ELEMENT);
     showElement(ALL_DROPDOWNS);
 }
 
@@ -1192,7 +1190,7 @@ function setupListHeader(p) {
 
 function configComplete() {
     util.log("configComplete()");
-    hideElement(MESSAGE_TEXT_ELEMENT);
+    hideElement(LOADING_TEXT_ELEMENT);
     showElement(START_STOP_BUTTON);
     setInterval(function() {
         if (!running) {

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -66,7 +66,7 @@ if (!fetch) {
         const buf = new ArrayBuffer(str.length);
         const bufView = new Uint8Array(buf);
 
-        for (let i = 0, strLen = str.length; i < strLen; i++) {
+        for (let i = 0, strLen = str.length; i < strLen -1; i++) {
             bufView[i] = str.charCodeAt(i);
         }
 

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -66,7 +66,7 @@ if (!fetch) {
         const buf = new ArrayBuffer(str.length);
         const bufView = new Uint8Array(buf);
 
-        for (let i = 0, strLen = str.length; i < strLen -1; i++) {
+        for (let i = 0, strLen = str.length; i < strLen; i++) {
             bufView[i] = str.charCodeAt(i);
         }
 

--- a/server/app-engine/templates/index.html
+++ b/server/app-engine/templates/index.html
@@ -12,7 +12,7 @@
   </head>
 
   <body style="background-color: var(--main-bg-color)" onblur="handleOnBlur()" onfocus="handleOnFocus()" onmouseup="handleTouch()" ontouchstart="handleTouch()">
-    <div id="qr-reader" style="width: 100%"></div>
+    <div id="qr-reader" style="width: 100%; display: block"></div>
     <div align="left" style="width: 100%">
         <button onclick="handleStartStop()" id="start-stop" style="display: none; background-color: green">Load trips</button>
     </div>
@@ -22,7 +22,7 @@
       <select id="driver-select" onchange="handleDriverChoice()" style="display: none; margin-left: 15px; width: 95%"></select>
       <button id="okay" disabled style="display:inline-block; margin-left: 10px">Go</button>
     </div>
-    <p id="loading" align="left" style="width: 100%; display: none" class="loading"> Loading GRaaS...</p>
+    <p id="message" align="left" style="width: 100%; display: none; white-space: pre-line;" class="message"> Loading GRaaS...</p>
     <div id="stats" style="width: 100%; display: none; padding-left: 25px" class="stats">
       <p id="version">Version: 0.18 (03/10/22)</p>
       <p id="trip-assignment-mode">Trip assignment mode:</p>

--- a/server/app-engine/templates/index.html
+++ b/server/app-engine/templates/index.html
@@ -22,7 +22,7 @@
       <select id="driver-select" onchange="handleDriverChoice()" style="display: none; margin-left: 15px; width: 95%"></select>
       <button id="okay" disabled style="display:inline-block; margin-left: 10px">Go</button>
     </div>
-    <p id="message" align="left" style="width: 100%; display: none; white-space: pre-line;" class="message"> Loading GRaaS...</p>
+    <p id="loading" align="left" style="width: 100%; display: none" class="loading"> Loading GRaaS...</p>
     <div id="stats" style="width: 100%; display: none; padding-left: 25px" class="stats">
       <p id="version">Version: 0.18 (03/10/22)</p>
       <p id="trip-assignment-mode">Trip assignment mode:</p>

--- a/server/app-engine/templates/index.html
+++ b/server/app-engine/templates/index.html
@@ -24,7 +24,8 @@
     </div>
     <p id="loading" align="left" style="width: 100%; display: none" class="loading"> Loading GRaaS...</p>
     <div id="stats" style="width: 100%; display: none; padding-left: 25px" class="stats">
-      <p id="version">Version: 0.16 (02/09/22)</p>
+      <p id="version">Version: 0.18 (03/10/22)</p>
+      <p id="trip-assignment-mode">Trip assignment mode:</p>
       <p id="vehicle-id">Vehicle ID:</p>
       <p id="uuid">UUID:</p>
       <p id="session-id">Session ID:</p>

--- a/server/app-engine/templates/index.html
+++ b/server/app-engine/templates/index.html
@@ -24,7 +24,7 @@
     </div>
     <p id="loading" align="left" style="width: 100%; display: none" class="loading"> Loading GRaaS...</p>
     <div id="stats" style="width: 100%; display: none; padding-left: 25px" class="stats">
-      <p id="version">Version: 0.18 (03/10/22)</p>
+      <p id="version">Version: 0.18 (03/17/22)</p>
       <p id="trip-assignment-mode">Trip assignment mode:</p>
       <p id="vehicle-id">Vehicle ID:</p>
       <p id="uuid">UUID:</p>


### PR DESCRIPTION
- Check whether agency's agency-config.json contains the optional use-bulk-assignment param (w/ a true value). If so, disable the trip selection dropdown.
- Report the trip-assignment-mode on the in-progress trip data view
- Begin caching vehicle ID, for 4 hours. If a driver stops a trip and starts again, regardless of bulk assignment mode, the vehicle-selection dropdown will auto-populate with the previously-selected value.
- A small amount of general cleanup