### PR TITLE
Add filtering for calendars.txt start_date and end_date to web app

### DIFF
--- a/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
+++ b/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
@@ -55,7 +55,7 @@ public class UpdateTripNames {
             long lastModifiedLRemote = Util.getLastModifiedRemote(gtfsURL);
             Debug.log("- lastModifiedLRemote: " + lastModifiedLRemote);
 
-            // if(lastModifiedLRemote > lastUpdatedTripList){
+            if(lastModifiedLRemote > lastUpdatedTripList){
                 Debug.log("Static GTFS has been updated since trip-names.json was last updated. Re-running TripListGenerator now to check whether this impacts trip-names.json");
 
                 String fileURL = "https://raw.githubusercontent.com/cal-itp/graas/main/" + filePath;
@@ -85,10 +85,10 @@ public class UpdateTripNames {
                 else{
                     Debug.log("No relevant changes detected.");
                 }
-            // }
-            // else{
-            //     Debug.log("trip-names.json has been updated since the last static GTFS update. Continuing.");
-            // }
+            }
+            else{
+                Debug.log("trip-names.json has been updated since the last static GTFS update. Continuing.");
+            }
         }
         if (prCount == 0) {
             reporter.addLine("...no agencies. Everything looks up to date.");

--- a/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
+++ b/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
@@ -55,7 +55,7 @@ public class UpdateTripNames {
             long lastModifiedLRemote = Util.getLastModifiedRemote(gtfsURL);
             Debug.log("- lastModifiedLRemote: " + lastModifiedLRemote);
 
-            if(lastModifiedLRemote > lastUpdatedTripList){
+            // if(lastModifiedLRemote > lastUpdatedTripList){
                 Debug.log("Static GTFS has been updated since trip-names.json was last updated. Re-running TripListGenerator now to check whether this impacts trip-names.json");
 
                 String fileURL = "https://raw.githubusercontent.com/cal-itp/graas/main/" + filePath;
@@ -85,10 +85,10 @@ public class UpdateTripNames {
                 else{
                     Debug.log("No relevant changes detected.");
                 }
-            }
-            else{
-                Debug.log("trip-names.json has been updated since the last static GTFS update. Continuing.");
-            }
+            // }
+            // else{
+            //     Debug.log("trip-names.json has been updated since the last static GTFS update. Continuing.");
+            // }
         }
         if (prCount == 0) {
             reporter.addLine("...no agencies. Everything looks up to date.");

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -992,7 +992,7 @@ function loadTrips() {
                 //util.log(`- time: ${time}`);
                 const dow = util.getDayOfWeek();
                 //util.log(`- dow: ${dow}`);
-                const date = util.getDate();
+                const date = util.getTodayYYYYMMDD();
                 util.log(`- date: ${date}`);
                 const lat = tripInfo.departure_pos.lat;
                 // util.log(`- lat: ${lat}`);

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -80,62 +80,6 @@ function isObject(obj) {
     return typeof obj === 'object' && obj !== null
 }
 
-// returns 0 for Monday...and 6 for Sunday
-function getDayOfWeek() {
-    if (testDow) {
-        return testDow;
-    } else return ((new Date()).getDay() + 6) % 7;
-}
-
-// returns date as an 8-character string (ie 20220317 for 3/17/22)
-function getDate() {
-    if (testDate) {
-        return testDate;
-    } else {
-        var today = new Date();
-        var year = today.getFullYear();
-        var month = today.getMonth() + 1;
-        var date = today.getDate();
-        return (year * 10000) + (month * 100) + date;
-    }
-}
-
-// 's' is assumed to be a time string like '8:23 am'
-function getTimeFromString(s) {
-    if (s == null){
-        util.log("* Time is null")
-        return null;
-    }
-    var cap = s.match(/([0-9]+):([0-9]+) ([ap]m)/);
-
-    var hour = parseInt(cap[1]);
-    var min = parseInt(cap[2]);
-    var ampm = cap[3];
-
-    if (ampm === 'pm'){
-        // 2:00pm becomes 14:00
-        if (hour < 12) hour += 12;
-        // note that 12:00pm stays 12:00
-    }
-    // 12:00am becomes 0:00
-    else if (hour === 12) hour = 0;
-
-    var date = new Date();
-    date.setHours(hour, min);
-    // util.log(" - date: " + date);
-    return date;
-}
-
-// return the difference in minutes between 's' and the current time.
-function getTimeDelta(s) {
-    var now = new Date();
-    if (testHour && testMin) {
-        now.setHours(testHour, testMin);
-    }
-    var tripTime = getTimeFromString(s);
-    return Math.abs((tripTime - now) / 60000);
-}
-
 function toRadians(degrees) {
     return degrees * (Math.PI / 180);
 }
@@ -1046,16 +990,16 @@ function loadTrips() {
             if (mode === 'vanilla' && isObject(tripInfo)) {
                 const time = getTimeFromName(tripInfo["trip_name"]);
                 //util.log(`- time: ${time}`);
-                const dow = getDayOfWeek();
+                const dow = util.getDayOfWeek();
                 //util.log(`- dow: ${dow}`);
-                const date = getDate();
+                const date = util.getDate();
                 util.log(`- date: ${date}`);
                 const lat = tripInfo.departure_pos.lat;
                 // util.log(`- lat: ${lat}`);
                 const lon = tripInfo.departure_pos.long;
                 // util.log(`- lon: ${lon}`);
 
-                const timeDelta = getTimeDelta(time);
+                const timeDelta = util.getTimeDelta(time);
                 // util.log(`- timeDelta: ${timeDelta}`);
 
                 const distance = getHaversineDistance(lat, lon, startLat, startLon);

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -89,6 +89,63 @@ if (!fetch) {
         return d;
     }
 
+
+    // returns 0 for Monday...and 6 for Sunday
+    exports.getDayOfWeek = function() {
+        if (testDow) {
+            return testDow;
+        } else return ((new Date()).getDay() + 6) % 7;
+    }
+
+    // returns date as an 8-character string (ie 20220317 for 3/17/22)
+    exports.getDate = function() {
+        if (testDate) {
+            return testDate;
+        } else {
+            var today = new Date();
+            var year = today.getFullYear();
+            var month = today.getMonth() + 1;
+            var date = today.getDate();
+            return (year * 10000) + (month * 100) + date;
+        }
+    }
+
+    // 's' is assumed to be a time string like '8:23 am'
+    function getTimeFromString(s) {
+        if (s == null){
+            util.log("* Time is null")
+            return null;
+        }
+        var cap = s.match(/([0-9]+):([0-9]+) ([ap]m)/);
+
+        var hour = parseInt(cap[1]);
+        var min = parseInt(cap[2]);
+        var ampm = cap[3];
+
+        if (ampm === 'pm'){
+            // 2:00pm becomes 14:00
+            if (hour < 12) hour += 12;
+            // note that 12:00pm stays 12:00
+        }
+        // 12:00am becomes 0:00
+        else if (hour === 12) hour = 0;
+
+        var date = new Date();
+        date.setHours(hour, min);
+        // util.log(" - date: " + date);
+        return date;
+    }
+
+    // return the difference in minutes between 's' and the current time.
+    exports.getTimeDelta = function(s) {
+        var now = new Date();
+        if (testHour && testMin) {
+            now.setHours(testHour, testMin);
+        }
+        var tripTime = getTimeFromString(s);
+        return Math.abs((tripTime - now) / 60000);
+    }
+
     exports.millisToSeconds = function(millis) {
         return Math.floor(millis / 1000);
     }

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -98,7 +98,7 @@ if (!fetch) {
     }
 
     // returns date as an 8-character string (ie 20220317 for 3/17/22)
-    exports.getDate = function() {
+    exports.getTodayYYYYMMDD = function() {
         if (testDate) {
             return testDate;
         } else {

--- a/server/app-engine/templates/index.html
+++ b/server/app-engine/templates/index.html
@@ -19,7 +19,6 @@
     <div id="config" align="left" style="width: 100%; display: none" class="config">
       <select id="trip-select" onchange="handleTripChoice()" style="margin-left: 15px; width: 95%"></select>
       <select id="bus-select" onchange="handleBusChoice()" style="margin-left: 15px; width: 95%"></select>
-      <select id="driver-select" onchange="handleDriverChoice()" style="display: none; margin-left: 15px; width: 95%"></select>
       <button id="okay" disabled style="display:inline-block; margin-left: 10px">Go</button>
     </div>
     <p id="loading" align="left" style="width: 100%; display: none" class="loading"> Loading GRaaS...</p>


### PR DESCRIPTION
- Filter based on logic in GTFS spec
- Filters can be overrided by ignore-start-end-date in agency-params.json
- Test value can be passed in via utm param: testdate
- This PR also removes two unused features: driver-select dropdown and "mode"

For a test agency, I confirmed:
- Filtering will show a trip if the current date is the start date or end date
- Filtering will not show a trip if current date is before start, or after end
- Filtering will show all trips if ignore-start-end-date is set to true (though, cache doesn't refresh immediately)