### PR TITLE
fix for 'trip_id' bug

### DIFF
--- a/server/app-engine/gtfsrt.py
+++ b/server/app-engine/gtfsrt.py
@@ -498,7 +498,7 @@ def handle_pos_update(datastore_client, timestamp_map, agency_map, position_lock
     data['rcv-timestamp'] = int(round(time.time()))
 
     ### TODO check if 'use-bulk-assignment-mode' == True
-    if data.get('trip_id', None) is None:
+    if data.get('trip-id', None) is None:
         trip_id = get_trip_id(
             datastore_client,
             data.get('agency-id', None),
@@ -507,6 +507,7 @@ def handle_pos_update(datastore_client, timestamp_map, agency_map, position_lock
         print(f'- trip_id: {trip_id}')
 
         if trip_id is None:
+            print(f'* discarding position update without trip ID: {data}')
             return
 
         data['trip_id'] = trip_id


### PR DESCRIPTION
recent changes introduced backfilling of missing trip IDs if possible. The issue is that the code in its current form looks for the name 'trip_id' when the actual name in the update is 'trip-id'.

This leads to all position updates being discarded before adding to DB and server vehicle maps.

As a first step, added tracing output when we discard a position update for missing trip ID.

Then, ran local server confirmed that trace is triggered with updates and current bug. Then, fixed bug and re-ran, confirming that trace is no longer triggered, and furthermore that trip ID backfilling code isn't called.