### PR TITLE
Update TripListGenerator to omit trips that reference a service_id missing from calendar.txt

### DIFF
--- a/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
@@ -420,6 +420,8 @@ class TripListEntry implements Comparable<TripListEntry> {
 
     public String toString(Map<String, CalendarData> cmap, Map<String, String>smap) {
         CalendarData calData = cmap.get(serviceID);
+        // Omit trips where the service_id is missing from calendar.txt.
+        // This is a temporary fix - the long term fix is to use info from calendar_dates as well. See https://github.com/cal-itp/graas/issues/19
         if(calData == null) {
             return null;
         } else {

--- a/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
@@ -244,15 +244,16 @@ public class TripListGenerator {
 
         for (int i=0; i<list.size(); i++) {
             TripListEntry e = list.get(i);
+            String row = e.toString(cmap, smap);
 
-            out.print("    ");
-            out.print(e.toString(cmap, smap));
-
-            if (i < list.size() - 1) {
-                out.print(",");
+            if(row != null){
+                out.print("    ");
+                out.print(row);
+                if (i < list.size() - 1) {
+                    out.print(",");
+                }
+                out.println();
             }
-
-            out.println();
         }
 
         out.println("]");
@@ -418,14 +419,19 @@ class TripListEntry implements Comparable<TripListEntry> {
     }
 
     public String toString(Map<String, CalendarData> cmap, Map<String, String>smap) {
-        return String.format("{\"trip_name\": \"%s @ %s\", \"trip_id\": \"%s\", \"calendar\": %s, \"departure_pos\": %s, \"start_date\": %s, \"end_date\": %s}",
-            name,
-            Time.getHMForMillis(departureTime),
-            tripID,
-            cmap.get(serviceID).dayList,
-            smap.get(firstStopID),
-            cmap.get(serviceID).startDate,
-            cmap.get(serviceID).endDate
-        );
+        CalendarData calData = cmap.get(serviceID);
+        if(calData == null) {
+            return null;
+        } else {
+            return String.format("{\"trip_name\": \"%s @ %s\", \"trip_id\": \"%s\", \"calendar\": %s, \"departure_pos\": %s, \"start_date\": %s, \"end_date\": %s}",
+                name,
+                Time.getHMForMillis(departureTime),
+                tripID,
+                calData.dayList,
+                smap.get(firstStopID),
+                calData.startDate,
+                calData.endDate
+            );
+        }
     }
 }

--- a/server/tests/stress-test-config.json
+++ b/server/tests/stress-test-config.json
@@ -2,8 +2,8 @@
 "use-production-server": true,
 "production-server-url": "https://lat-long-prototype.wl.r.appspot.com/",
 "agency-count": 5,
-"vehicle-count": 1,
+"vehicle-count": 5,
 "interval-time": 3,
 "interval-variation": 1,
-"num-repeats": 1
+"num-repeats": 3
 }

--- a/server/tests/stress-test-config.json
+++ b/server/tests/stress-test-config.json
@@ -2,8 +2,8 @@
 "use-production-server": true,
 "production-server-url": "https://lat-long-prototype.wl.r.appspot.com/",
 "agency-count": 5,
-"vehicle-count": 5,
+"vehicle-count": 1,
 "interval-time": 3,
 "interval-variation": 1,
-"num-repeats": 3
+"num-repeats": 1
 }


### PR DESCRIPTION
When a trip has a service_id that is missing from calendar.txt, the most likely reason is that the service_id is instead listed in calendar_dates.txt. This solution simply skips these trips.

This issue caused https://github.com/cal-itp/graas/issues/191

This is a short term patch, and should be addressed long-term via https://github.com/cal-itp/graas/issues/19.

