### PR TITLE
indicate block assignment data validity using dates, not times

### DIFF
--- a/server/app-engine/index.yaml
+++ b/server/app-engine/index.yaml
@@ -19,8 +19,7 @@ indexes:
 - kind: block-metadata
   properties:
   - name: agency_id
-  - name: valid_from
-  - name: valid_to
+  - name: valid_date
   - name: created
     direction: desc
 

--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -343,8 +343,7 @@ function handleKey(id) {
 
         var data = {
             'agency_id': agencyID,
-            'valid_from': Math.floor(fromDate.getTime() / 1000),
-            'valid_to': Math.floor(toDate.getTime() / 1000),
+            'valid_date': util.getYYYYMMDD(fromDate),
             'blocks': blockData
         };
         util.log('- data: ' + JSON.stringify(data));

--- a/server/app-engine/util.py
+++ b/server/app-engine/util.py
@@ -127,6 +127,14 @@ def get_seconds_since_midnight(seconds = None):
     now = PACIFIC_TZ.localize(now)
     return int((now - now.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds())
 
+def get_yyyymmdd(date = None):
+    if date is None:
+        date = datetime.now()
+
+    date = PACIFIC_TZ.localize(date)
+    return f'{date.year}-{date.month}-{date.day}'
+
+
 # For new instances of GRaaS, replace 'graas-resources' with a globally unique directory name in the below two functions:
 def update_bucket_timestamp():
     client = storage.Client()


### PR DESCRIPTION
Use a date in the form of yyyy-mm-dd to mark block assignment data validity, instead of unix time stamps. The latter are susceptible to time zone issues, depending on where in the world the client code runs.

I already pushed the index.yaml change, which means the previous dispatch UI won't work until this is merged.