### PR TITLE
Bugfix/update dependencies

### DIFF
--- a/server/app-engine/requirements.txt
+++ b/server/app-engine/requirements.txt
@@ -9,3 +9,4 @@ ecdsa==0.16.0
 google-cloud-ndb==1.11.1
 google-cloud-storage==1.43.0
 itsdangerous==2.0.1
+pytz==2021.1

--- a/server/app-engine/requirements.txt
+++ b/server/app-engine/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.0.3
 google-cloud-datastore==1.15.3
 google-auth<2
 requests==2.23.0
@@ -9,4 +9,3 @@ ecdsa==0.16.0
 google-cloud-ndb==1.11.1
 google-cloud-storage==1.43.0
 itsdangerous==2.0.1
-pytz==2021.1

--- a/server/tests/stress-test-config.json
+++ b/server/tests/stress-test-config.json
@@ -1,8 +1,8 @@
 {
 "use-production-server": true,
 "production-server-url": "https://lat-long-prototype.wl.r.appspot.com/",
-"agency-count": 50,
-"vehicle-count": 3,
+"agency-count": 5,
+"vehicle-count": 5,
 "interval-time": 3,
 "interval-variation": 1,
 "num-repeats": 3

--- a/server/tests/stress-test-config.json
+++ b/server/tests/stress-test-config.json
@@ -1,8 +1,8 @@
 {
 "use-production-server": true,
 "production-server-url": "https://lat-long-prototype.wl.r.appspot.com/",
-"agency-count": 5,
-"vehicle-count": 5,
+"agency-count": 50,
+"vehicle-count": 3,
 "interval-time": 3,
 "interval-variation": 1,
 "num-repeats": 3


### PR DESCRIPTION
web app deploy had the error:
```
ImportError: cannot import name 'escape' from 'jinja2' (/layers/google.python.pip/pip/lib/python3.7/site-packages/jinja2/__init__.py)
```

Updating flask did the trick - and the front end (viewable [here](https://20220329t215335-dot-lat-long-prototype.wl.r.appspot.com/)) is looking good.

The next step will be to migrate traffic later tonight and then perform backend tests (or to continue looking into how to perform backend tests on a single version)

