### PR TITLE
Refactor TripListGenerator to use Util.LoadCollections

### DIFF
--- a/gtfu/src/main/java/gtfu/Calendar.java
+++ b/gtfu/src/main/java/gtfu/Calendar.java
@@ -1,6 +1,7 @@
 package gtfu;
 
 import java.util.Date;
+import java.util.Arrays;
 
 public class Calendar {
     public static final int MONDAY    = java.util.Calendar.MONDAY;
@@ -15,11 +16,15 @@ public class Calendar {
 
     private String serviceID;
     private int days[];
+    private String startDate;
+    private String endDate;
     private long startMillis;
     private long endMillis;
 
-    public Calendar(String serviceID, int monday, int tuesday, int wednesday, int thursday, int friday, int saturday, int sunday, long startMillis, long endMillis) {
+    public Calendar(String serviceID, int monday, int tuesday, int wednesday, int thursday, int friday, int saturday, int sunday, String startDate, String endDate, long startMillis, long endMillis) {
         this.serviceID = serviceID;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.startMillis = startMillis;
         this.endMillis = endMillis;
 
@@ -51,6 +56,14 @@ public class Calendar {
         return days[dow] != 0;
     }
 
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+
     public String toShortList() {
         StringBuffer sb = new StringBuffer();
 
@@ -69,6 +82,29 @@ public class Calendar {
             sb.append(days[n] == 0 ? '-' : LETTERS.charAt(i));
         }
 
+        return sb.toString();
+    }
+
+    public String toArrayString() {
+        StringBuffer sb = new StringBuffer();
+
+        /*
+        0 -> 2
+        1 -> 3
+        2 -> 4
+        3 -> 5
+        4 -> 6
+        5 -> 7
+        6 -> 1
+        */
+
+        sb.append("[");
+        for (int i=0; i<7; i++) {
+            int n = ((i + 1) % 7 + 1);
+            sb.append(days[n] == 0 ? "0" : "1");
+            sb.append(i < 6 ? ", " : "");
+        }
+        sb.append("]");
         return sb.toString();
     }
 }

--- a/gtfu/src/main/java/gtfu/Calendar.java
+++ b/gtfu/src/main/java/gtfu/Calendar.java
@@ -76,8 +76,8 @@ public class Calendar {
         6 -> 1
         */
 
-        for (int i=0; i<7; i++) {
-            int n = ((i + 1) % 7 + 1);
+        for (int i=0; i<Time.DAYS_PER_WEEK; i++) {
+            int n = ((i + 1) % Time.DAYS_PER_WEEK + 1);
             sb.append(days[n] == 0 ? '-' : LETTERS.charAt(i));
         }
 
@@ -98,10 +98,10 @@ public class Calendar {
         */
 
         sb.append("[");
-        for (int i=0; i<7; i++) {
-            int n = ((i + 1) % 7 + 1);
+        for (int i=0; i<Time.DAYS_PER_WEEK; i++) {
+            int n = ((i + 1) % Time.DAYS_PER_WEEK + 1);
             sb.append(days[n] == 0 ? "0" : "1");
-            sb.append(i < 6 ? ", " : "");
+            sb.append(i < Time.DAYS_PER_WEEK - 1 ? ", " : "");
         }
         sb.append("]");
         return sb.toString();

--- a/gtfu/src/main/java/gtfu/Calendar.java
+++ b/gtfu/src/main/java/gtfu/Calendar.java
@@ -1,7 +1,6 @@
 package gtfu;
 
 import java.util.Date;
-import java.util.Arrays;
 
 public class Calendar {
     public static final int MONDAY    = java.util.Calendar.MONDAY;

--- a/gtfu/src/main/java/gtfu/CalendarCollection.java
+++ b/gtfu/src/main/java/gtfu/CalendarCollection.java
@@ -40,6 +40,8 @@ public class CalendarCollection implements Iterable<Calendar>, Serializable {
                 r.getInt("friday"),
                 r.getInt("saturday"),
                 r.getInt("sunday"),
+                r.get("start_date"),
+                r.get("end_date"),
                 Time.parseDateAsLong(DATE_FORMAT, r.get("start_date")),
                 Time.parseDateAsLong(DATE_FORMAT, r.get("end_date"))
             );

--- a/gtfu/src/main/java/gtfu/Direction.java
+++ b/gtfu/src/main/java/gtfu/Direction.java
@@ -17,42 +17,11 @@ public class Direction implements Serializable {
     String name;
 
     public Direction(String routeDirectionID, String routeID, String directionID, String name) {
-        this();
 
         this.routeDirectionID = routeDirectionID;
         this.routeID = routeID;
         this.directionID = directionID;
         this.name = name;
-    }
-
-    private Direction() {
-    }
-
-    public void write(DataOutputStream out) {
-        try {
-            out.writeUTF(routeDirectionID);
-            out.writeUTF(routeID);
-            out.writeUTF(directionID);
-            out.writeUTF(name);
-
-        } catch (IOException e) {
-            throw new Fail(e);
-        }
-    }
-
-    public static Direction fromStream(DataInputStream in) {
-        try {
-            Direction d = new Direction();
-
-            d.routeDirectionID = in.readUTF();
-            d.routeID = in.readUTF();
-            d.directionID = in.readUTF();
-            d.name = in.readUTF();
-
-            return d;
-        } catch (IOException e) {
-            throw new Fail(e);
-        }
     }
 
     public String getRouteDirectionID() {

--- a/gtfu/src/main/java/gtfu/Direction.java
+++ b/gtfu/src/main/java/gtfu/Direction.java
@@ -1,0 +1,65 @@
+package gtfu;
+
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Direction implements Serializable {
+    String routeDirectionID;
+    String routeID;
+    String directionID;
+    String name;
+
+    public Direction(String routeDirectionID, String routeID, String directionID, String name) {
+        this();
+
+        this.routeDirectionID = routeDirectionID;
+        this.routeID = routeID;
+        this.directionID = directionID;
+        this.name = name;
+    }
+
+    private Direction() {
+    }
+
+    public void write(DataOutputStream out) {
+        try {
+            out.writeUTF(routeDirectionID);
+            out.writeUTF(routeID);
+            out.writeUTF(directionID);
+            out.writeUTF(name);
+
+        } catch (IOException e) {
+            throw new Fail(e);
+        }
+    }
+
+    public static Direction fromStream(DataInputStream in) {
+        try {
+            Direction d = new Direction();
+
+            d.routeDirectionID = in.readUTF();
+            d.routeID = in.readUTF();
+            d.directionID = in.readUTF();
+            d.name = in.readUTF();
+
+            return d;
+        } catch (IOException e) {
+            throw new Fail(e);
+        }
+    }
+
+    public String getRouteDirectionID() {
+        return routeDirectionID;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/gtfu/src/main/java/gtfu/DirectionCollection.java
+++ b/gtfu/src/main/java/gtfu/DirectionCollection.java
@@ -46,54 +46,13 @@ public class DirectionCollection implements Iterable<Direction>, Serializable {
             tf.dispose();
         }
         catch (Exception e){
-            Util.fail(
-                String.format(
-                    "* Error: directions.txt is not present"
-                ),
-                !skipErrors
-            );
+            e.printStackTrace();
         }
     }
 
     private DirectionCollection() {
         map = new HashMap<String, Direction>();
         list = new ArrayList<Direction>();
-    }
-
-    public void write(DataOutputStream out) {
-        try {
-            out.writeInt(list.size());
-            int count = 0;
-
-            for (Direction d : list) {
-                d.write(out);
-            }
-        } catch (IOException e) {
-            throw new Fail(e);
-        }
-    }
-
-    public static DirectionCollection fromStream(DataInputStream in) {
-        try {
-            DirectionCollection c = new DirectionCollection();
-
-            int count = in.readInt();
-
-            for (int i=0; i<count; i++) {
-                Direction d = Direction.fromStream(in);
-
-                c.list.add(d);
-                c.map.put(d.getRouteDirectionID(), d);
-            }
-
-            return c;
-        } catch (IOException e) {
-            throw new Fail(e);
-        }
-    }
-
-    public Direction get(int index) {
-        return list.get(index);
     }
 
     public Direction get(String id) {

--- a/gtfu/src/main/java/gtfu/DirectionCollection.java
+++ b/gtfu/src/main/java/gtfu/DirectionCollection.java
@@ -1,0 +1,118 @@
+package gtfu;
+
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+public class DirectionCollection implements Iterable<Direction>, Serializable {
+    private Map<String, Direction> map;
+    private List<Direction> list;
+
+    // route_direction_id, route_id, direction_id
+    public DirectionCollection(String path) {
+        this(path, false);
+    }
+
+    public DirectionCollection(String path, boolean skipErrors) {
+        this();
+        try{
+            TextFile tf = new TextFile(path + "/directions.txt");
+            CSVHeader header = new CSVHeader(tf.getNextLine());
+
+            for (;;) {
+                String line = tf.getNextLine();
+                if (line == null) break;
+
+                CSVRecord r = new CSVRecord(header, line);
+                String routeID = r.get("route_id");
+                String directionID = r.get("direction_id");
+                String routeDirectionID = routeID + "-" + directionID;
+                String name = r.get("direction");
+                Direction direction = new Direction(routeDirectionID, routeID, directionID, name);
+
+                map.put(routeDirectionID, direction);
+                list.add(direction);
+            }
+
+            tf.dispose();
+        }
+        catch (Exception e){
+            Util.fail(
+                String.format(
+                    "* Error: directions.txt is not present"
+                ),
+                !skipErrors
+            );
+        }
+    }
+
+    private DirectionCollection() {
+        map = new HashMap<String, Direction>();
+        list = new ArrayList<Direction>();
+    }
+
+    public void write(DataOutputStream out) {
+        try {
+            out.writeInt(list.size());
+            int count = 0;
+
+            for (Direction d : list) {
+                d.write(out);
+            }
+        } catch (IOException e) {
+            throw new Fail(e);
+        }
+    }
+
+    public static DirectionCollection fromStream(DataInputStream in) {
+        try {
+            DirectionCollection c = new DirectionCollection();
+
+            int count = in.readInt();
+
+            for (int i=0; i<count; i++) {
+                Direction d = Direction.fromStream(in);
+
+                c.list.add(d);
+                c.map.put(d.getRouteDirectionID(), d);
+            }
+
+            return c;
+        } catch (IOException e) {
+            throw new Fail(e);
+        }
+    }
+
+    public Direction get(int index) {
+        return list.get(index);
+    }
+
+    public Direction get(String id) {
+        return map.get(id);
+    }
+
+    public int getSize() {
+        return list.size();
+    }
+
+    public void forEach(Consumer<? super Direction> action) {
+        list.forEach(action);
+    }
+
+    public Iterator<Direction> iterator() {
+        return list.iterator();
+    }
+
+    public Spliterator<Direction> spliterator() {
+        return list.spliterator();
+    }
+}

--- a/gtfu/src/main/java/gtfu/Route.java
+++ b/gtfu/src/main/java/gtfu/Route.java
@@ -14,16 +14,20 @@ public class Route implements Filterable, Serializable {
     String id;
     String agencyID;
     String name;
+    String longName;
+    String shortName;
     transient Color color;
     List<Trip> tripList;
     Area area;
 
-    public Route(String id, String agencyID, String name, Color color) {
+    public Route(String id, String agencyID, String name, String longName, String shortName, Color color) {
         this();
 
         this.id = id;
         this.agencyID = agencyID;
         this.name = name;
+        this.longName = longName;
+        this.shortName = shortName;
         this.color = color;
 
         area = new Area();
@@ -112,6 +116,14 @@ public class Route implements Filterable, Serializable {
 
     public String getName() {
         return name;
+    }
+
+    public String getLongName() {
+        return longName;
+    }
+
+    public String getShortName() {
+        return shortName;
     }
 
     public void addTrip(Trip trip) {

--- a/gtfu/src/main/java/gtfu/RouteCollection.java
+++ b/gtfu/src/main/java/gtfu/RouteCollection.java
@@ -41,6 +41,8 @@ public class RouteCollection implements Iterable<Route>, Serializable {
                 name = r.get("route_short_name");
             }
 
+            String longName = r.get("route_long_name");
+            String shortName = r.get("route_short_name");
             String hexRGB = r.get("route_color");
             //Debug.log("- hexRGB: " + hexRGB);
 
@@ -50,7 +52,7 @@ public class RouteCollection implements Iterable<Route>, Serializable {
 
             Color color = Util.getColorFromHexString(hexRGB);
 
-            Route route = new Route(id, agencyID, name, color);
+            Route route = new Route(id, agencyID, name, longName, shortName, color);
             //Debug.log("  - " + id + ": " + name);
 
             map.put(id, route);

--- a/gtfu/src/main/java/gtfu/Time.java
+++ b/gtfu/src/main/java/gtfu/Time.java
@@ -18,6 +18,8 @@ public class Time {
     public static final int MILLIS_PER_HOUR   = 60 * MILLIS_PER_MINUTE;
     public static final int MILLIS_PER_DAY    = 24 * MILLIS_PER_HOUR;
 
+    public static final int DAYS_PER_WEEK = 7;
+
     public static long getMidnightTimestamp() {
         return getMidnightTimestamp(Util.now());
     }

--- a/gtfu/src/main/java/gtfu/Trip.java
+++ b/gtfu/src/main/java/gtfu/Trip.java
@@ -15,6 +15,7 @@ public class Trip implements Serializable {
     String serviceID;
     String headsign;
     String blockID;
+    String directionID;
     List<Stop> stopList;
     List<Integer> milliList;
     Map<String, Integer> stopMap;
@@ -24,7 +25,7 @@ public class Trip implements Serializable {
     int accelerator;
     int startTime;
 
-    public Trip(String id, String routeID, String serviceID, String headsign, Shape shape) {
+    public Trip(String id, String routeID, String serviceID, String headsign, Shape shape, String directionID) {
         this();
 
         this.id = id;
@@ -32,6 +33,7 @@ public class Trip implements Serializable {
         this.serviceID = serviceID;
         this.headsign = headsign;
         this.shape = shape;
+        this.directionID = directionID;
         shapeID = shape.getID();
         //Debug.log("- shapeID: " + shapeID);
 
@@ -131,6 +133,10 @@ public class Trip implements Serializable {
 
     public String getBlockID() {
         return blockID;
+    }
+
+    public String getDirectionID() {
+        return directionID;
     }
 
     public void setSchedule(TripSchedule schedule) {

--- a/gtfu/src/main/java/gtfu/TripCollection.java
+++ b/gtfu/src/main/java/gtfu/TripCollection.java
@@ -41,6 +41,7 @@ public class TripCollection implements Iterable<Trip>, Serializable {
             String headSign = r.get("trip_headsign");
             String shapeID = r.get("shape_id");
             String blockID = r.get("block_id");
+            String directionID = r.get("direction_id");
             Shape shape = shapeCollection.get(shapeID);
             if (shape == null) {
                 Util.fail(
@@ -52,7 +53,7 @@ public class TripCollection implements Iterable<Trip>, Serializable {
                     !skipErrors
                 );
             } else {
-                Trip trip = new Trip(id, routeID, serviceID, headSign, shape);
+                Trip trip = new Trip(id, routeID, serviceID, headSign, shape, directionID);
                 trip.setBlockID(blockID);
 
                 map.put(id, trip);

--- a/gtfu/src/main/java/gtfu/Util.java
+++ b/gtfu/src/main/java/gtfu/Util.java
@@ -880,7 +880,8 @@ public class Util {
 
         //Debug.log("directions:");
         t = new Timer("directions");
-        DirectionCollection directionCollection = new DirectionCollection(path, skipErrors);
+        // Not all agencies use directions.txt, so skipErrors is set to always be true
+        DirectionCollection directionCollection = new DirectionCollection(path, true);
         collections.put("directions", directionCollection);
         t.dumpLap();
 

--- a/gtfu/src/main/java/gtfu/Util.java
+++ b/gtfu/src/main/java/gtfu/Util.java
@@ -878,6 +878,12 @@ public class Util {
         collections.put("routes", routeCollection);
         t.dumpLap();
 
+        //Debug.log("directions:");
+        t = new Timer("directions");
+        DirectionCollection directionCollection = new DirectionCollection(path, skipErrors);
+        collections.put("directions", directionCollection);
+        t.dumpLap();
+
         for (Route route : routeCollection) {
             route.computeArea();
         }

--- a/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
@@ -49,7 +49,17 @@ public class BlockDataGenerator {
         Debug.log("- date: " + date);
         Debug.log("- uploadToGcloud: " + uploadToGcloud);
 
-        Map<String, Object> collections = Util.loadCollections(cacheFolder, agencyID, new ConsoleProgressObserver(40));
+        AgencyYML a = new AgencyYML();
+        String gtfsUrl = a.getURL(agencyID);
+
+        if (gtfsUrl == null) {
+            System.out.println(agencyID + " does not appear in agencies.yml, exiting");
+            System.exit(1);
+        }
+
+        ConsoleProgressObserver progressObserver = new ConsoleProgressObserver(40);
+        Util.updateCacheIfNeeded(cacheFolder, agencyID, gtfsUrl, progressObserver);
+        Map<String, Object> collections = Util.loadCollections(cacheFolder, agencyID, progressObserver);
         CalendarCollection calendars = (CalendarCollection)collections.get("calendars");
         TripCollection trips = (TripCollection)collections.get("trips");
         BlockCollection blocks = new BlockCollection(calendars, trips, date);

--- a/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
@@ -24,6 +24,7 @@ public class TripListGenerator {
 
     private static final String[] WEEKDAYS = {"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"};
     private static final String reportPath = "src/main/resources/conf/output";
+    private static Map<String, String> customDirectionMap = new HashMap();
 
     /**
      * Generate the triplist and print it to the provided PrintStream. If you pass only these 3 args, useValidator
@@ -96,6 +97,10 @@ public class TripListGenerator {
 
         out.println("[");
 
+        if(useDirection && directions.getSize() == 0){
+            customDirectionMap = createCustomDirectionMap();
+        }
+
         for(int i = 0; i < trips.getSize(); i++){
 
             Trip trip = trips.get(i);
@@ -111,15 +116,20 @@ public class TripListGenerator {
             } else if (nameField.equals("route_short_name")){
                 name = route.getShortName();
             }
-            TODO:
+
             if(useDirection){
-                Direction direction = directions.get(trip.getRouteID() + "-" + trip.getDirectionID());
-                String directionName = direction.getName();
-                name += " - " + directionName;
+                if(directions.getSize() > 0){
+                    Direction direction = directions.get(trip.getRouteID() + "-" + trip.getDirectionID());
+                    String directionName = direction.getName();
+                    name += " - " + directionName;
+                }
+                else{
+                    String directionName = customDirectionMap.get(trip.getDirectionID());
+                    name += " - " + directionName;
+                }
             }
-
+            // Once we solve for calendar_dates, calendar should never be null
             if(calendar != null){
-
                 String tripInfo = String.format("{\"trip_name\": \"%s @ %s\", \"trip_id\": \"%s\", \"calendar\": %s, \"departure_pos\": {\"lat\": %s, \"long\": %s}, \"start_date\": %s, \"end_date\": %s}",
                                     name,
                                     Time.getHMForSeconds(trip.getStartTime(), true),
@@ -200,15 +210,15 @@ public class TripListGenerator {
 
         // tf.dispose();
 
-
     // For agencies who don't include the optional directions.txt file, assume the following mapping.
     // This is designed specifically around Unitrans
-    // private static Map<String, String> createDirectionMap() {
-    //     Map<String,String> directionMap = new HashMap<String,String>();
-    //     directionMap.put("0", "Outbound");
-    //     directionMap.put("1", "Inbound");
-    //     return directionMap;
-    // }
+    private static Map<String, String> createCustomDirectionMap() {
+        Map<String,String> directionMap = new HashMap();
+        directionMap.put("0", "Outbound");
+        directionMap.put("1", "Inbound");
+        return directionMap;
+    }
+
 
     private static void usage() {
         System.err.println("usage: TripListGenerator [-t|--temp-folder <tmp-folder>] -a|--agency-id <agency-id> [-o|--output-file <output-path>] [-a|--gtfs-agency <gtfs-agency-id>] [-r|-R|-h]");

--- a/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
@@ -92,6 +92,7 @@ public class TripListGenerator {
         CalendarCollection calendars = (CalendarCollection)collections.get("calendars");
         TripCollection trips = (TripCollection)collections.get("trips");
         RouteCollection routes = (RouteCollection)collections.get("routes");
+        DirectionCollection directions = (DirectionCollection)collections.get("directions");
 
         out.println("[");
 
@@ -110,10 +111,12 @@ public class TripListGenerator {
             } else if (nameField.equals("route_short_name")){
                 name = route.getShortName();
             }
-            // TODO:
-            // if(useDirection){
-            //     name += " - " + direction;
-            // }
+            TODO:
+            if(useDirection){
+                Direction direction = directions.get(trip.getRouteID() + "-" + trip.getDirectionID());
+                String directionName = direction.getName();
+                name += " - " + directionName;
+            }
 
             if(calendar != null){
 

--- a/gtfu/src/test/java/gtfu/test/TestBadStaticGTFS.java
+++ b/gtfu/src/test/java/gtfu/test/TestBadStaticGTFS.java
@@ -18,7 +18,7 @@ public class TestBadStaticGTFS {
         FailureReporter reporter = new NullFailureReporter();
         Util.setReporter(reporter);
 
-        int expectedFailures = 31;
+        int expectedFailures = 30;
         String cachePath = "src/test/resources/test-gtfs/";
         String agencyID = "bad-static-gtfs";
 

--- a/gtfu/src/test/java/gtfu/test/TestBadStaticGTFS.java
+++ b/gtfu/src/test/java/gtfu/test/TestBadStaticGTFS.java
@@ -18,7 +18,7 @@ public class TestBadStaticGTFS {
         FailureReporter reporter = new NullFailureReporter();
         Util.setReporter(reporter);
 
-        int expectedFailures = 30;
+        int expectedFailures = 31;
         String cachePath = "src/test/resources/test-gtfs/";
         String agencyID = "bad-static-gtfs";
 


### PR DESCRIPTION
Refactor TLG to use existing functions - and add bits of missing functionality to Util.LoadCollections as needed. Also add Direction and DirectionCollection classes.

I ran UpdateTripNames on all live agencies for a final diff comparison, and the only difference is some rounding on lat and long points. Looks like the result of Float.parseFloat() in StopCollection.java, but I'm inclined to ignore this because: 1) The difference is a matter of feed and 2) It should be now using lat and long values that match the rest of GTFU standard classes. You can see these diffs as they are all sitting in PR drafts.

Separately, I also updated Block Generator to use Util.updateCacheIfNeeded(), as it appears it was using an expired cache. I tested this by re-running the nightly block generation job.