### PR TITLE
bulk assignment UI work

### DIFF
--- a/gtfu/src/main/java/gtfu/Time.java
+++ b/gtfu/src/main/java/gtfu/Time.java
@@ -81,7 +81,7 @@ public class Time {
     }
 
 
-    // seconds are a millisecond resolution offset into a day
+    // seconds are a second resolution offset into a day
     public static String getHMForSeconds(int seconds, boolean includeAMPM) {
         int hour = seconds / SECONDS_PER_HOUR;
         seconds -= hour * SECONDS_PER_HOUR;

--- a/gtfu/src/main/java/gtfu/Util.java
+++ b/gtfu/src/main/java/gtfu/Util.java
@@ -883,12 +883,14 @@ public class Util {
         collections.put("routes", routeCollection);
         t.dumpLap();
 
-        //Debug.log("directions:");
-        t = new Timer("directions");
-        // Not all agencies use directions.txt, so skipErrors is set to always be true
-        DirectionCollection directionCollection = new DirectionCollection(path, true);
-        collections.put("directions", directionCollection);
-        t.dumpLap();
+        File df = new File(path + "/directions.txt");
+        if (df.exists()) {
+            //Debug.log("directions:");
+            t = new Timer("directions");
+            DirectionCollection directionCollection = new DirectionCollection(path, skipErrors);
+            collections.put("directions", directionCollection);
+            t.dumpLap();
+        }
 
         for (Route route : routeCollection) {
             route.computeArea();

--- a/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
@@ -78,7 +78,7 @@ public class BlockDataGenerator {
                 Trip trip = trips.get(tripID);
 
                 tr.id = tripID;
-                tr.headSign = trip.getHeadsign();
+                tr.headsign = trip.getHeadsign();
                 tr.startTime = trip.getStartTime();
                 tr.endTime = tr.startTime + trip.getDurationInSeconds();
 
@@ -126,7 +126,7 @@ public class BlockDataGenerator {
     private static void usage() {
         System.err.println("usage: BlockDataGenerator -a|--agency-id <agency-id> [-U|--url <static-gtfs-url>] -u|--upload [-c|--cache-folder <cache-folder>] [-o|--output-folder <output-folder>] [-d|--date <mm/dd/yy>|<n>]");
         System.err.println("    <agency-id> a transit agency identifier constructed from the alphabet of [a-z\\-]");
-        System.err.println("    <static-gtfs-url> link to agency's static static GTFS data. System attempts to backfill with data from agency.yaml if omitted");
+        System.err.println("    <static-gtfs-url> optional link to agency's static static GTFS data. For agencies present in agencies.yml, the URL will be loaded automatically");
         System.err.println("    use -u or --upload flag to upload files directly to Google Cloud");
         System.err.println("    <cache-folder> a temp folder for unpacking and caching static GTFS data by agency");
         System.err.println("    <output-folder> folder to place output file in (file name will be 'blocks-<mm>-<dd>.json'");
@@ -203,7 +203,7 @@ public class BlockDataGenerator {
 
     class TripRecord {
         public String id;
-        public String headSign;
+        public String headsign;
         public int startTime;
         public int endTime;
     }

--- a/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
@@ -76,6 +76,7 @@ public class BlockDataGenerator {
                 Trip trip = trips.get(tripID);
 
                 tr.id = tripID;
+                tr.headSign = trip.getHeadsign();
                 tr.startTime = trip.getStartTime();
                 tr.endTime = tr.startTime + trip.getDurationInSeconds();
 
@@ -193,6 +194,7 @@ public class BlockDataGenerator {
 
     class TripRecord {
         public String id;
+        public String headSign;
         public int startTime;
         public int endTime;
     }

--- a/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/BlockDataGenerator.java
@@ -21,7 +21,7 @@ public class BlockDataGenerator {
     * @param offset     how many days in advance to generate data for.
     */
     public BlockDataGenerator(String agencyID, Integer offset) throws Exception {
-        new BlockDataGenerator("src/main/resources/conf/cache", null, agencyID, getDateFromOffset(offset), true);
+        new BlockDataGenerator("src/main/resources/conf/cache", null, agencyID, null, getDateFromOffset(offset), true);
     }
 
     /**
@@ -32,7 +32,7 @@ public class BlockDataGenerator {
     * @param date           Date to generate block data for
     * @param uploadToGcloud Whether or not to upload results to gcloud rather than downloading
     */
-    public BlockDataGenerator(String cacheFolder, String outputFolder, String agencyID, Date date, Boolean uploadToGcloud) throws Exception {
+    public BlockDataGenerator(String cacheFolder, String outputFolder, String agencyID, String gtfsURL, Date date, Boolean uploadToGcloud) throws Exception {
 
         if(outputFolder == null){
             outputFolder = System.getenv("HOME") + "/tmp";
@@ -49,16 +49,18 @@ public class BlockDataGenerator {
         Debug.log("- date: " + date);
         Debug.log("- uploadToGcloud: " + uploadToGcloud);
 
-        AgencyYML a = new AgencyYML();
-        String gtfsUrl = a.getURL(agencyID);
+        if (gtfsURL == null) {
+            AgencyYML a = new AgencyYML();
+            gtfsURL = a.getURL(agencyID);
+        }
 
-        if (gtfsUrl == null) {
+        if (gtfsURL == null) {
             System.out.println(agencyID + " does not appear in agencies.yml, exiting");
             System.exit(1);
         }
 
         ConsoleProgressObserver progressObserver = new ConsoleProgressObserver(40);
-        Util.updateCacheIfNeeded(cacheFolder, agencyID, gtfsUrl, progressObserver);
+        Util.updateCacheIfNeeded(cacheFolder, agencyID, gtfsURL, progressObserver);
         Map<String, Object> collections = Util.loadCollections(cacheFolder, agencyID, progressObserver);
         CalendarCollection calendars = (CalendarCollection)collections.get("calendars");
         TripCollection trips = (TripCollection)collections.get("trips");
@@ -122,8 +124,9 @@ public class BlockDataGenerator {
     }
 
     private static void usage() {
-        System.err.println("usage: BlockDataGenerator -a|--agency-id <agency-id> -u|--upload [-c|--cache-folder <cache-folder>] [-o|--output-folder <output-folder>] [-d|--date <mm/dd/yy>|<n>]");
+        System.err.println("usage: BlockDataGenerator -a|--agency-id <agency-id> [-U|--url <static-gtfs-url>] -u|--upload [-c|--cache-folder <cache-folder>] [-o|--output-folder <output-folder>] [-d|--date <mm/dd/yy>|<n>]");
         System.err.println("    <agency-id> a transit agency identifier constructed from the alphabet of [a-z\\-]");
+        System.err.println("    <static-gtfs-url> link to agency's static static GTFS data. System attempts to backfill with data from agency.yaml if omitted");
         System.err.println("    use -u or --upload flag to upload files directly to Google Cloud");
         System.err.println("    <cache-folder> a temp folder for unpacking and caching static GTFS data by agency");
         System.err.println("    <output-folder> folder to place output file in (file name will be 'blocks-<mm>-<dd>.json'");
@@ -143,6 +146,7 @@ public class BlockDataGenerator {
         String cacheFolder = null;
         String agencyID = null;
         String outputFolder = null;
+        String gtfsURL = null;
         Date date = new Date();
         Boolean uploadToGcloud = false;
 
@@ -159,6 +163,11 @@ public class BlockDataGenerator {
 
             if ((arg[i].equals("-a") || arg[i].equals("--agency-id")) && i < arg.length - 1) {
                 agencyID = arg[++i];
+                continue;
+            }
+
+            if ((arg[i].equals("-U") || arg[i].equals("--url")) && i < arg.length - 1) {
+                gtfsURL = arg[++i];
                 continue;
             }
 
@@ -189,7 +198,7 @@ public class BlockDataGenerator {
 
         if (agencyID == null) usage();
 
-        new BlockDataGenerator(cacheFolder, outputFolder, agencyID, date, uploadToGcloud);
+        new BlockDataGenerator(cacheFolder, outputFolder, agencyID, gtfsURL, date, uploadToGcloud);
     }
 
     class TripRecord {

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -18,6 +18,17 @@ var fetch = this.fetch
 const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_HOUR   = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY    = 24 * SECONDS_PER_HOUR;
+const SECONDS_PER_WEEK   =  7 * SECONDS_PER_DAY;
+
+const MILLIS_PER_SECOND = 1000;
+const MILLIS_PER_MINUTE = 60 * MILLIS_PER_SECOND;
+const MILLIS_PER_HOUR   = 60 * MILLIS_PER_MINUTE;
+const MILLIS_PER_DAY    = 24 * MILLIS_PER_HOUR;
+
+
 if (!crypto) {
     crypto = require('crypto').webcrypto
 }
@@ -111,7 +122,7 @@ if (!fetch) {
     }
 
     // 's' is assumed to be a time string like '8:23 am'
-    function getTimeFromString(s) {
+    exports.getTimeFromString = function(s) {
         if (s == null){
             util.log("* Time is null")
             return null;
@@ -134,6 +145,22 @@ if (!fetch) {
         date.setHours(hour, min);
         // util.log(" - date: " + date);
         return date;
+    }
+
+    // create H:MM string from day seconds, optionally include am/pm indicator
+    exports.getHMForSeconds = function(daySeconds, includeAMPM) {
+        var hour = Math.floor(daySeconds / SECONDS_PER_HOUR);
+        daySeconds -= hour * SECONDS_PER_HOUR;
+        const min = Math.floor(daySeconds / SECONDS_PER_MINUTE);
+
+        const amPm = hour >= 12 ? ' pm' : ' am';
+
+        if (hour == 0) hour = 12;
+        else if (hour > 12) hour -= 12;
+
+        const ms = ('' + min).padStart(2, '0');
+        const aps = includeAMPM ? amPm : '';
+        return `${hour}:${ms}${aps}`
     }
 
     // return the difference in minutes between 's' and the current time.

--- a/server/app-engine/static/vehicle-assignment-index.html
+++ b/server/app-engine/static/vehicle-assignment-index.html
@@ -45,7 +45,7 @@
             <p id="item-label" style="float: left; text-align: left; font-family: arial; color: black; font-size: 20px; margin-top: 37px; margin-left: 10px"></p>
         </div>
         <div id="descoverlay" onclick="descriptionOff()">
-            <div id="desctext"></div>
+            <div id="desctext" style="font-family: arial; font-size: 20px"></div>
         </div>
         <script src="../static/gtfs-rt-util.js"></script>
         <script src="../static/vehicle-assignments.js"></script>

--- a/server/app-engine/static/vehicle-assignment-index.html
+++ b/server/app-engine/static/vehicle-assignment-index.html
@@ -41,7 +41,8 @@
         <canvas id="canvas"></canvas>
         <div style="width: 100%; display: block">
             <button id="key-deploy" onclick="handleKey(this.id)" style="width: auto; float: right; display: none;" class="btn">Deploy</button>
-            <p id="text-deployment-status" style="float: right; text-align: right; font-family: arial; color: lightGray; font-size: 14px; margin-top: 37px"></p>
+            <p id="text-deployment-status" style="float: right; text-align: right; font-family: arial; color: lightGray; font-size: 14px; margin-top: 39px"></p>
+            <p id="item-label" style="float: left; text-align: left; font-family: arial; color: black; font-size: 20px; margin-top: 37px; margin-left: 10px">Full label goes right here</p>
         </div>
         <div id="descoverlay" onclick="descriptionOff()">
             <div id="desctext"></div>

--- a/server/app-engine/static/vehicle-assignment-index.html
+++ b/server/app-engine/static/vehicle-assignment-index.html
@@ -43,6 +43,9 @@
             <button id="key-deploy" onclick="handleKey(this.id)" style="width: auto; float: right; display: none;" class="btn">Deploy</button>
             <p id="text-deployment-status" style="float: right; text-align: right; font-family: arial; color: lightGray; font-size: 14px; margin-top: 37px"></p>
         </div>
+        <div id="descoverlay" onclick="descriptionOff()">
+            <div id="desctext"></div>
+        </div>
         <script src="../static/gtfs-rt-util.js"></script>
         <script src="../static/vehicle-assignments.js"></script>
     </body>

--- a/server/app-engine/static/vehicle-assignment-index.html
+++ b/server/app-engine/static/vehicle-assignment-index.html
@@ -42,7 +42,7 @@
         <div style="width: 100%; display: block">
             <button id="key-deploy" onclick="handleKey(this.id)" style="width: auto; float: right; display: none;" class="btn">Deploy</button>
             <p id="text-deployment-status" style="float: right; text-align: right; font-family: arial; color: lightGray; font-size: 14px; margin-top: 39px"></p>
-            <p id="item-label" style="float: left; text-align: left; font-family: arial; color: black; font-size: 20px; margin-top: 37px; margin-left: 10px">Full label goes right here</p>
+            <p id="item-label" style="float: left; text-align: left; font-family: arial; color: black; font-size: 20px; margin-top: 37px; margin-left: 10px"></p>
         </div>
         <div id="descoverlay" onclick="descriptionOff()">
             <div id="desctext"></div>

--- a/server/app-engine/static/vehicle-assignment-style.css
+++ b/server/app-engine/static/vehicle-assignment-style.css
@@ -12,7 +12,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0,0,0,0.75);
+  background-color: rgba(0,0,0,0.83);
   z-index: 2;
   cursor: pointer;
 }

--- a/server/app-engine/static/vehicle-assignment-style.css
+++ b/server/app-engine/static/vehicle-assignment-style.css
@@ -12,7 +12,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0,0,0,0.83);
+  background-color: rgba(255, 255, 255, .83);
   z-index: 2;
   cursor: pointer;
 }
@@ -22,7 +22,7 @@
   top: 50%;
   left: 50%;
   font-size: 16px;
-  color: white;
+  color: black;
   transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
 }

--- a/server/app-engine/static/vehicle-assignment-style.css
+++ b/server/app-engine/static/vehicle-assignment-style.css
@@ -3,6 +3,30 @@
   padding:0;
 }
 
+#descoverlay {
+  position: fixed;
+  display: none;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.75);
+  z-index: 2;
+  cursor: pointer;
+}
+
+#desctext{
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  font-size: 16px;
+  color: white;
+  transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+}
+
 html, body {
   width:100%;
   height:100%;

--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -543,23 +543,21 @@ function createFriendlyBlockDescription(block) {
             times += ', ';
         }
 
-        times += util.getHMForSeconds(trip.start_time, true);
+        times += util.getHMForSeconds(trip.start_time, false);
 
         map[headSign] = times;
     }
 
-    var desc = '';
+    var desc = `<b>BLOCK ${block.id}:</b><br><hr><br>`;
 
     for (const [key, value] of Object.entries(map)) {
-      desc += `${key} ${value}\n`;
+      desc += `- <b>${key}</b> ${value} <br><br>`;
     }
 
     //util.log('- block.id: ' + block.id);
     //util.log('- desc: ' + desc);
 
     blockDescriptions[block.id] = desc;
-
-    return desc;
 }
 
 async function loadBlockData(dateString) {
@@ -797,6 +795,15 @@ function longPress(x, y) {
     }
 }
 
+function descriptionOn() {
+  document.getElementById("descoverlay").style.display = "block";
+}
+
+function descriptionOff() {
+  document.getElementById("descoverlay").style.display = "none";
+}
+
+
 function handleMouseDown(e) {
     util.log('handleMouseDown()');
     util.log('- e: ' + JSON.stringify(e));
@@ -831,6 +838,20 @@ function handleMouseDown(e) {
             dragItem = item;
             //log('- dragItem: ' + dragItem);
             repaint();
+            break;
+        }
+
+        if (item.type === 'block'
+            && x >= item.x && x < item.x + item.w && y >= item.y && y < item.y + item.h)
+        {
+            var desc = blockDescriptions[item.label];
+
+            if (desc) {
+                var elem = document.getElementById('desctext');
+                elem.innerHTML = desc;
+                descriptionOn();
+            }
+
             break;
         }
     }

--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -779,7 +779,11 @@ function longPress(x, y) {
         pressItem.status = 'unassigned';
         pressItem.vehicle = null;
         repaint();
+    } else if (pressItem.type === 'block') {
+        drawFullLabel(pressItem.label);
+        descriptionOn(blockDescriptions[pressItem.label]);
     }
+
 
     if (blockID) {
         showToast(`unassigned block '${blockID}'`);
@@ -795,14 +799,18 @@ function longPress(x, y) {
     }
 }
 
-function descriptionOn() {
-  document.getElementById("descoverlay").style.display = "block";
+function descriptionOn(desc) {
+    if (!desc) return;
+
+    var elem = document.getElementById('desctext');
+    elem.innerHTML = desc;
+
+    document.getElementById("descoverlay").style.display = "block";
 }
 
 function descriptionOff() {
-  document.getElementById("descoverlay").style.display = "none";
+    document.getElementById("descoverlay").style.display = "none";
 }
-
 
 function handleMouseDown(e) {
     util.log('handleMouseDown()');
@@ -841,17 +849,10 @@ function handleMouseDown(e) {
             break;
         }
 
-        if (item.type === 'block'
+        if (!isMobile() && item.type === 'block'
             && x >= item.x && x < item.x + item.w && y >= item.y && y < item.y + item.h)
         {
-            var desc = blockDescriptions[item.label];
-
-            if (desc) {
-                var elem = document.getElementById('desctext');
-                elem.innerHTML = desc;
-                descriptionOn();
-            }
-
+            descriptionOn(blockDescriptions[item.label]);
             break;
         }
     }

--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -530,8 +530,7 @@ function createFriendlyBlockDescription(block) {
     const map = {};
 
     for (var trip of block.trips) {
-        var headSign = trip.head_sign;
-        var times = map[headSign];
+        var times = map[trip.headsign];
 
         if (!times) {
             times = '@';
@@ -545,7 +544,7 @@ function createFriendlyBlockDescription(block) {
 
         times += util.getHMForSeconds(trip.start_time, true);
 
-        map[headSign] = times;
+        map[trip.headsign] = times;
     }
 
     var desc = `<b>BLOCK ${block.id}:</b><br><hr><br>`;

--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -543,7 +543,7 @@ function createFriendlyBlockDescription(block) {
             times += ', ';
         }
 
-        times += util.getHMForSeconds(trip.start_time, false);
+        times += util.getHMForSeconds(trip.start_time, true);
 
         map[headSign] = times;
     }
@@ -928,12 +928,15 @@ function drawFullLabel(label) {
     //util.log('drawFullLabel()');
     //util.log('- label: ' + label);
 
-    ctx.shadowColor = 'rgba(0,0,0,0)';
+    /*ctx.shadowColor = 'rgba(0,0,0,0)';
     ctx.fillStyle = 'black';
     ctx.textAlign = 'left';
 
     const inset = 5;
-    ctx.fillText(label, inset, canvas.height - 2 * inset);
+    ctx.fillText(label, inset, canvas.height - 2 * inset);*/
+
+    var elem = document.getElementById('item-label');
+    elem.innerHTML = label;
 }
 
 function handleMouseMove(e) {
@@ -1014,12 +1017,12 @@ function handleMouseMove(e) {
 
                 if (x >= item.x - skirt && x < item.x + item.w  + skirt && y >= item.y - skirt && y < item.y + item.h + skirt)
                 {
-                    if (metrics.width > elementWidth - 10) {
+                    if (true /*metrics.width > elementWidth - 10*/) {
                         repaint();
                         drawFullLabel(item.label);
                     }
 
-                    if (item.type === 'block') {
+                    /*if (item.type === 'block') {
                         const blockID = item.label;
 
                         if (blockID !== lastHoveredBlockID) {
@@ -1028,7 +1031,7 @@ function handleMouseMove(e) {
 
                             lastHoveredBlockID = blockID;
                         }
-                    }
+                    }*/
 
                     break;
                 }

--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -890,6 +890,7 @@ function handleMouseUp(e) {
 }
 
 function drawCloseButton(item) {
+    //util.log('drawCloseButton()');
     repaint();
 
     var xx = item.x + item.w;
@@ -928,15 +929,8 @@ function drawFullLabel(label) {
     //util.log('drawFullLabel()');
     //util.log('- label: ' + label);
 
-    /*ctx.shadowColor = 'rgba(0,0,0,0)';
-    ctx.fillStyle = 'black';
-    ctx.textAlign = 'left';
-
-    const inset = 5;
-    ctx.fillText(label, inset, canvas.height - 2 * inset);*/
-
     var elem = document.getElementById('item-label');
-    elem.innerHTML = label;
+    elem.innerHTML = 'ID: ' + label;
 }
 
 function handleMouseMove(e) {
@@ -1018,20 +1012,8 @@ function handleMouseMove(e) {
                 if (x >= item.x - skirt && x < item.x + item.w  + skirt && y >= item.y - skirt && y < item.y + item.h + skirt)
                 {
                     if (true /*metrics.width > elementWidth - 10*/) {
-                        repaint();
                         drawFullLabel(item.label);
                     }
-
-                    /*if (item.type === 'block') {
-                        const blockID = item.label;
-
-                        if (blockID !== lastHoveredBlockID) {
-                            const desc = blockDescriptions[item.label];
-                            util.log('- desc: ' + desc);
-
-                            lastHoveredBlockID = blockID;
-                        }
-                    }*/
 
                     break;
                 }


### PR DESCRIPTION
- clip labels that are too long and add ellipses, show full label on hover/long press
- show a friendly description for blocks upon click/long press (block ID and then a list of head signs, each with a list of departure times) 
- works for both desktop and mobile

A couple of items that snuck in but aren't actually bulk assignment UI:
- don't choke on missing `directions.txt` in `Util.loadCollections()`
- allow `BlockDataGenerator` to work on agencies not present in agencies.yaml