### PR TITLE
Automerge tripname changes

### DIFF
--- a/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
+++ b/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
@@ -98,13 +98,11 @@ public class GitHubUtil {
     * @param file           Byte array representation of file
     * @param message        Commit message
     * @param branchName     Name for new branch
+    * @param autoMerge      Whether or not the PR should be merged automatically
     */
-    public GHPullRequest createCommitAndPR(String title, String description, String path, byte[] file, String message, String branchName) throws Exception {
+    public void createCommitAndPR(String title, String description, String path, byte[] file, String message, String branchName, Boolean autoMerge) throws Exception {
         createCommit(branchName, message, path, file);
-        return createPR(title, branchName, description);
-    }
-
-    public void mergePR(GHPullRequest pr, String message) throws Exception {
-        pr.merge(message);
+        GHPullRequest pr = createPR(title, branchName, description);
+        if(autoMerge) pr.merge(message);
     }
 }

--- a/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
+++ b/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
@@ -85,8 +85,8 @@ public class GitHubUtil {
         GHRef branch = repo.createRef("refs/heads/" + branchName, commit.getSHA1());
     }
 
-    private void createPR(String title, String branchName, String description) throws Exception {
-        GHPullRequest pr = repo.createPullRequest(title, branchName, MAIN_BRANCH_NAME, description);
+    private GHPullRequest createPR(String title, String branchName, String description) throws Exception {
+        return repo.createPullRequest(title, branchName, MAIN_BRANCH_NAME, description);
     }
 
     /**
@@ -99,8 +99,12 @@ public class GitHubUtil {
     * @param message        Commit message
     * @param branchName     Name for new branch
     */
-    public void createCommitAndPR(String title, String description, String path, byte[] file, String message, String branchName) throws Exception {
+    public GHPullRequest createCommitAndPR(String title, String description, String path, byte[] file, String message, String branchName) throws Exception {
         createCommit(branchName, message, path, file);
-        createPR(title, branchName, description);
+        return createPR(title, branchName, description);
+    }
+
+    public void mergePR(GHPullRequest pr, String message) throws Exception {
+        pr.merge(message);
     }
 }

--- a/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
+++ b/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
@@ -85,8 +85,9 @@ public class GitHubUtil {
         GHRef branch = repo.createRef("refs/heads/" + branchName, commit.getSHA1());
     }
 
-    private GHPullRequest createPR(String title, String branchName, String description) throws Exception {
-        return repo.createPullRequest(title, branchName, MAIN_BRANCH_NAME, description);
+    private void createPR(String title, String branchName, String description, Boolean autoMerge) throws Exception {
+        GHPullRequest pr = repo.createPullRequest(title, branchName, MAIN_BRANCH_NAME, description);
+        if(autoMerge) pr.merge("Merging automatically");
     }
 
     /**
@@ -102,7 +103,6 @@ public class GitHubUtil {
     */
     public void createCommitAndPR(String title, String description, String path, byte[] file, String message, String branchName, Boolean autoMerge) throws Exception {
         createCommit(branchName, message, path, file);
-        GHPullRequest pr = createPR(title, branchName, description);
-        if(autoMerge) pr.merge(message);
+        createPR(title, branchName, description, autoMerge);
     }
 }

--- a/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
+++ b/gtfu/src/main/java/gtfu/tools/GitHubUtil.java
@@ -85,7 +85,7 @@ public class GitHubUtil {
         GHRef branch = repo.createRef("refs/heads/" + branchName, commit.getSHA1());
     }
 
-    private void createPR(String title, String branchName, String description, Boolean autoMerge) throws Exception {
+    private void createPR(String title, String branchName, String description, boolean autoMerge) throws Exception {
         GHPullRequest pr = repo.createPullRequest(title, branchName, MAIN_BRANCH_NAME, description);
         if(autoMerge) pr.merge("Merging automatically");
     }
@@ -101,7 +101,7 @@ public class GitHubUtil {
     * @param branchName     Name for new branch
     * @param autoMerge      Whether or not the PR should be merged automatically
     */
-    public void createCommitAndPR(String title, String description, String path, byte[] file, String message, String branchName, Boolean autoMerge) throws Exception {
+    public void createCommitAndPR(String title, String description, String path, byte[] file, String message, String branchName, boolean autoMerge) throws Exception {
         createCommit(branchName, message, path, file);
         createPR(title, branchName, description, autoMerge);
     }

--- a/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
+++ b/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
@@ -14,8 +14,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
-import org.kohsuke.github.GHPullRequest;
-
 /**
  * Creates PR's to update each active agency's trip-names.json file, if needed.
  */
@@ -85,26 +83,21 @@ public class UpdateTripNames {
                     boolean autoMerge = lengthDiverence < LENGTH_DIVERGENCE_MAX;
 
                     String title = ":robot: updates to " + agencyID + " triplist";
+                    String message = "Update trip-names.json to reflect static GTFS updates";
+                    String branchName = agencyID + "-triplist-update-" + Util.now();
                     String description = "Our automated daily check detected that changes were made to " + agencyID + "'s static GTFS.";
 
                     if(autoMerge) {
                         description += "This PR merged automatically because the file changed by less than " + (LENGTH_DIVERGENCE_MAX * 100) + "%";
                         reportLine += "Automerged PR";
+                        Debug.log("Automerging PR");
                     } else {
                         description += "This PR was automatically generated, so please review and make updates if necessary before merging";
                         reportLine += "Please review PR";
+
                     }
 
-                    String message = "Update trip-names.json to reflect static GTFS updates";
-                    String branchName = agencyID + "-triplist-update-" + Util.now();
-
-                    GHPullRequest pr = gh.createCommitAndPR(title, description, filePath, newFile, message, branchName);
-
-                    if(autoMerge){
-                        Debug.log("Auto-merging PR");
-                        gh.mergePR(pr,"Auto-merging PR");
-                    }
-
+                    gh.createCommitAndPR(title, description, filePath, newFile, message, branchName, autoMerge);
                     reporter.addLine(reportLine);
                     prCount++;
                 }

--- a/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
+++ b/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
@@ -30,7 +30,7 @@ public class UpdateTripNames {
     }
 
     /**
-     * Checks whether each agency has updated their static GTFS feed since the latest update to trip-names.json. If they have, it runs TripListGenerator, regenerateAlls the new trip with the old one, and creates a PR if the new one differs.
+     * Checks whether each agency has updated their static GTFS feed since the latest update to trip-names.json. If they have, it runs TripListGenerator, compares the new trip with the old one, and creates a PR if the new one differs.
      * @param agencyIDList A list of agencyIDs
      * @param regenerateAll     A true value will run the comparison even if there is no recent update detected
      */

--- a/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
+++ b/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
@@ -101,7 +101,6 @@ public class UpdateTripNames {
                     } else {
                         description += "This PR was automatically generated, so please review and make updates if necessary before merging";
                         reportLine += "Please review PR";
-
                     }
 
                     gh.createCommitAndPR(title, description, filePath, newFile, message, branchName, autoMerge);

--- a/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
+++ b/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
@@ -18,7 +18,7 @@ import java.nio.charset.StandardCharsets;
  * Creates PR's to update each active agency's trip-names.json file, if needed.
  */
 public class UpdateTripNames {
-    private static final double LENGTH_DIVERGENCE_MAX = 0.10;
+    private static final double LENGTH_DIVERGENCE_MAX = 0.05;
     /**
      * Runs UpdateTripNames for a single agency
      * @param agencyID The agencyiD

--- a/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
+++ b/gtfu/src/main/java/gtfu/tools/UpdateTripNames.java
@@ -105,7 +105,7 @@ public class UpdateTripNames {
                         reportLine += "Please review PR";
                     }
 
-                    // gh.createCommitAndPR(title, description, filePath, newFile, message, branchName, autoMerge);
+                    gh.createCommitAndPR(title, description, filePath, newFile, message, branchName, autoMerge);
                     reporter.addLine(reportLine);
                     prCount++;
                 }


### PR DESCRIPTION
When small changes to trip-names.json are detected (currently defined by a % difference in byte array length of <5%), automerge the PR rather than waiting for approval.

Also add a flag to UpdateTripNames.json which runs the comparison regardless of whether or not there was a recent update. This is useful for when we update TripListGenerator output and for testing, as it prevents us from having to manually comment out code.

I tested this by editing gtfs files and ensuring that a 5% difference in byte array length correlates to what I intuitively thing that would be (ie just a few lines, depending on length of course).