### PR TITLE
Reduce friction for bulk assignment mode

### DIFF
--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -341,6 +341,7 @@ function handleStartStop() {
         configMatrix.setSelected(CONFIG_TRIP_NAMES, false);
         configMatrix.setSelected(CONFIG_VEHICLE_IDS, false);
 
+        vehicleIDCookie = getCookie(VEHICLE_ID_COOKIE_NAME);
         if(vehicleIDCookie){
             assignValue(BUS_SELECT_DROPDOWN, vehicleIDCookie);
             handleBusChoice();

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -1137,8 +1137,6 @@ function configComplete() {
     util.log("configComplete()");
 
     vehicleIDCookie = getCookie(VEHICLE_ID_COOKIE_NAME);
-    util.log("vehicle ID cookie value: " + vehicleID);
-    util.log("useBulkAssignmentMode: " + useBulkAssignmentMode);
     hideElement(LOADING_TEXT_ELEMENT);
 
     // If bulk assignment mode and vehicleID is already cached, simply start tracking

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -1142,6 +1142,7 @@ function configComplete() {
 
     // If bulk assignment mode and vehicleID is already cached, simply start tracking
     if(vehicleIDCookie && useBulkAssignmentMode){
+        assignValue(BUS_SELECT_DROPDOWN, vehicleIDCookie);
         handleOkay()
     }
     // If bulk assignment mode and vehicleID is NOT cached, present vehicleID dropdown

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -46,9 +46,9 @@ const UUID_NAME = 'lat_long_id';
 const VEHICLE_ID_COOKIE_NAME = 'vehicle_id';
 var vehicleIDCookie = null;
 const MSG_NO = 'msg_no';
-const MAX_AGE_SECS = 10 * 60 * 60 * 24 * 365;
-const MAX_LIFE_MILLIS = 1000 * 60 * 60 * 24 * 7;
-const MAX_VEHICLE_ID_AGE_SECS = 60 * 60 * 4;
+const MAX_AGE_SECS = util.SECONDS_PER_YEAR * 10;
+const MAX_LIFE_MILLIS = util.MILLIS_PER_DAY * 7;
+const MAX_VEHICLE_ID_AGE_SECS = util.SECONDS_PER_YEAR * 10;
 
 const PEM_HEADER = "-----BEGIN TOKEN-----";
 const PEM_FOOTER = "-----END TOKEN-----";
@@ -341,11 +341,8 @@ function handleStartStop() {
         configMatrix.setSelected(CONFIG_TRIP_NAMES, false);
         configMatrix.setSelected(CONFIG_VEHICLE_IDS, false);
 
-        vehicleIDCookie = getCookie(VEHICLE_ID_COOKIE_NAME);
-
         if(vehicleIDCookie){
-            let p = document.getElementById(BUS_SELECT_DROPDOWN);
-            p.value = vehicleIDCookie;
+            assignValue(BUS_SELECT_DROPDOWN, vehicleIDCookie);
             handleBusChoice();
         }
 
@@ -1082,8 +1079,7 @@ function populateList(id, str, list) {
 }
 
 function disableElement(id) {
-    let p = document.getElementById(id);
-    p.value = 'disabled'
+    assignValue(id, 'disabled');
 }
 
 function disableElements(list) {
@@ -1106,6 +1102,11 @@ function changeDisplay(id,display) {
 function changeText(id,text) {
     let p = document.getElementById(id);
     p.textContent = text;
+}
+
+function assignValue(id, value){
+    let p = document.getElementById(id);
+    p.value = value;
 }
 
 // Populates dropdown, and then shows all dropdowns
@@ -1133,8 +1134,25 @@ function setupListHeader(listElem) {
 
 function configComplete() {
     util.log("configComplete()");
+
+    vehicleIDCookie = getCookie(VEHICLE_ID_COOKIE_NAME);
+    util.log("vehicle ID cookie value: " + vehicleID);
+    util.log("useBulkAssignmentMode: " + useBulkAssignmentMode);
     hideElement(LOADING_TEXT_ELEMENT);
-    showElement(START_STOP_BUTTON);
+
+    // If bulk assignment mode and vehicleID is already cached, simply start tracking
+    if(vehicleIDCookie && useBulkAssignmentMode){
+        handleOkay()
+    }
+    // If bulk assignment mode and vehicleID is NOT cached, present vehicleID dropdown
+    else if(useBulkAssignmentMode){
+        handleStartStop()
+    }
+    // If not bulk assignment mode, present the "Load trips" button.
+    else{
+        showElement(START_STOP_BUTTON);
+    }
+
     setInterval(function() {
         if (!running) {
             util.log("checking for updated version..");

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -31,6 +31,7 @@ if (!fetch) {
     exports.SECONDS_PER_HOUR   = 60 * exports.SECONDS_PER_MINUTE;
     exports.SECONDS_PER_DAY    = 24 * exports.SECONDS_PER_HOUR;
     exports.SECONDS_PER_WEEK   =  7 * exports.SECONDS_PER_DAY;
+    exports.SECONDS_PER_YEAR   =  365 * exports.SECONDS_PER_DAY;
 
     exports.MILLIS_PER_SECOND = 1000;
     exports.MILLIS_PER_MINUTE =   60 * exports.MILLIS_PER_SECOND;

--- a/server/app-engine/static/index.html
+++ b/server/app-engine/static/index.html
@@ -23,7 +23,7 @@
     </div>
     <p id="loading" align="left" style="width: 100%; display: none" class="loading"> Loading GRaaS...</p>
     <div id="stats" style="width: 100%; display: none; padding-left: 25px" class="stats">
-      <p id="version">Version: 0.19 (03/21/22)</p>
+      <p id="version">Version: 0.20 (05/09/22)</p>
       <p id="trip-assignment-mode">Trip assignment mode:</p>
       <p id="vehicle-id">Vehicle ID:</p>
       <p id="uuid">UUID:</p>


### PR DESCRIPTION
1. When bulk assignment mode is enabled and there is a vehicle ID cached, immediately load the "posting updates" view, with no option to stop trip.
2. When bulk assignment mode is enabled and there is not yet a vehicleID cached, show the vehicle-id dropdown without a "Load trips" button. Once selected and "go" is pressed, load the "posting updates" view, with no option to stop trip.
3. Normal behavior when bulk assignment mode is not enabled. Auto populate vehicleID dropdown (it can be manually changed though) 