### PR TITLE
include more failures to LoadAgencyDataTest email

### DIFF
--- a/gtfu/src/test/java/gtfu/test/LoadAgencyDataTest.java
+++ b/gtfu/src/test/java/gtfu/test/LoadAgencyDataTest.java
@@ -94,7 +94,7 @@ public class LoadAgencyDataTest {
             try {
                 new LoadAgencyDataTest(cacheDir, agencyID);
             } catch (Exception e) {
-                Debug.error("* test failed: " + e);
+                Util.fail("* test failed: " + e, false);
             }
         } else {
             ProgressObserver po = new ConsoleProgressObserver(40);
@@ -109,7 +109,7 @@ public class LoadAgencyDataTest {
                 try {
                     new LoadAgencyDataTest(cacheDir, id);
                 } catch (Exception e) {
-                    Debug.error("* test failed: " + e);
+                    Util.fail("* test failed: " + e, false);
                 }
             }
         }


### PR DESCRIPTION
[This issue](https://github.com/cal-itp/graas/issues/292) occurred last night, when connection to CAE gtfs url timed out. The initial issue, at least, is that our LoadAgencyData test email showed up clean for CAE, when it should have showed an error message. This update includes errors loading their into the email.

It doesn't address the root cause of the connection timing out, but I'm not yet convinced that we have control over that issue.