### PR TITLE
fix server deployment

### DIFF
--- a/server/app-engine/requirements.txt
+++ b/server/app-engine/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-ndb==1.11.1
 google-cloud-storage==1.43.0
 itsdangerous==2.0.1
 pytz==2021.1
+protobuf==3.20.1


### PR DESCRIPTION
Huffing along on the deprecation treadmill: as of today, server deploys would fail catastrophically with the server dying on startup, and clients getting `HTTP ERROR 502 Bad Gateway`.

python package and server sub-dependency `protobuf` had a release last Friday, which seems to cause serious issues. Explicitly pinning version for `protobuf` to 3.20.1.

Tested by deploying to staging, then 1) curling the target URL and 2) running a node test to push a position update. Both tests will fail if deploy is unsuccessful.