### PR TITLE
Service alert UI

### DIFF
--- a/gtfu/src/main/java/gtfu/Util.java
+++ b/gtfu/src/main/java/gtfu/Util.java
@@ -864,11 +864,14 @@ public class Util {
         t.dumpLap();
         Debug.log("- calendarCollection.getSize(): " + calendarCollection.getSize());
 
-        t = new Timer("calendar_dates");
-        CalendarDateCollection calendarDateCollection = new CalendarDateCollection(path);
-        collections.put("calendar_dates", calendarDateCollection);
-        t.dumpLap();
-        Debug.log("- calendarDateCollection.getSize(): " + calendarDateCollection.getSize());
+        File cd = new File(path + "/calendar_dates.txt");
+        if (cd.exists()) {
+            t = new Timer("calendar_dates");
+            CalendarDateCollection calendarDateCollection = new CalendarDateCollection(path);
+            collections.put("calendar_dates", calendarDateCollection);
+            t.dumpLap();
+            Debug.log("- calendarDateCollection.getSize(): " + calendarDateCollection.getSize());
+        }
 
         //Debug.log("shapes:");
         t = new Timer("shapes");

--- a/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
+++ b/gtfu/src/main/java/gtfu/tools/TripListGenerator.java
@@ -47,10 +47,11 @@ public class TripListGenerator {
             System.exit(1);
         }
 
-        byte[] bytes = GCloudStorage.getObject("graas-resources","gtfs-aux/" + agencyID + "/agency-params.json");
+        String fileURL = "https://raw.githubusercontent.com/cal-itp/graas/main/server/agency-config/gtfs/gtfs-aux/" + agencyID + "/agency-params.json";
+        ConsoleProgressObserver progressObserver = new ConsoleProgressObserver(40);
+        byte[] bytes = Util.getURLContentBytes(fileURL, progressObserver);
         JSONParser parser = new JSONParser();
         JSONObject agencyParams = (JSONObject) parser.parse(new String(bytes, StandardCharsets.UTF_8));
-
 
         Boolean useDirection = (Boolean) agencyParams.get("triplist-generator-use-direction");
 
@@ -85,8 +86,6 @@ public class TripListGenerator {
                 in.close();
             }
         }
-
-        ConsoleProgressObserver progressObserver = new ConsoleProgressObserver(40);
         Util.updateCacheIfNeeded(cacheFolder, agencyID, gtfsURL, progressObserver);
 
         Map<String, Object> collections = Util.loadCollections(cacheFolder, agencyID, progressObserver);

--- a/server/app-engine/gtfsrt.py
+++ b/server/app-engine/gtfsrt.py
@@ -290,6 +290,31 @@ def add_alert(datastore_client, alert):
     datastore_client.put(entity)
     print('+ wrote alert')
 
+def delete_alert(datastore_client, alert):
+    print('delete_alert()')
+    print('- alert: ' + str(alert))
+
+    query = datastore_client.query(kind='alert')
+    # We need to filter for all fields, since a unique ID isn't passed into the protobuf
+    # query.add_filter('agency_key', '=', alert["agency_key"])
+    query.add_filter('cause', '=', alert["cause"])
+    # query.add_filter('effect', '=', alert["effect"])
+    # query.add_filter('description', '=', alert["description"])
+    query.add_filter('time_start', '=', alert["time_start"])
+    query.add_filter('time_stop', '=', alert["time_stop"])
+    # add filter for all fields
+    results = list(query.fetch(limit=20))
+    key_list = []
+
+    for alert in results:
+        print('-- alert to delete: ' + str(alert))
+        key_list.append(alert.key)
+
+    print('- key_list: ' + str(key_list))
+
+    datastore_client.delete_multi(key_list)
+    print('+ deleted alert')
+
 def add_position(datastore_client, pos):
     entity = datastore.Entity(key=datastore_client.key('position'))
     entity.update(pos)

--- a/server/app-engine/gtfsrt.py
+++ b/server/app-engine/gtfsrt.py
@@ -59,16 +59,19 @@ def make_translated_string(text):
 def make_entity_selector(item):
     selector = gtfs_realtime_pb2.EntitySelector()
 
-    if 'agency_id' in item:
+    if 'agency_id' in item and item['agency_id'] != None:
         selector.agency_id = item['agency_id']
 
-    if 'route_id' in item:
+    if 'route_id' in item and item['route_id'] != None:
         selector.route_id = item['route_id']
 
-    if 'stop_id' in item:
+    if 'stop_id' in item and item['stop_id'] != None:
         selector.stop_id = item['stop_id']
 
-    if 'trip_id' in item:
+    if 'route_type' in item and item['route_type'] != None:
+        selector.route_type = item['route_type']
+
+    if 'trip_id' in item and item['trip_id'] != None:
         trip = gtfs_realtime_pb2.TripDescriptor()
         trip.trip_id = item['trip_id']
         selector.trip.CopyFrom(trip)
@@ -271,11 +274,12 @@ def add_alert(datastore_client, alert):
         print('alert doesn\'t have associated agency, discarding')
         return
 
-    if not('time_start' in alert and 'time_stop' in alert):
-        print('alert doesn\'t have valid time range, discarding')
-        return
+    # Per the spec, alerts without a time range will just live forever until removed
+    # if not('time_start' in alert and 'time_stop' in alert):
+    #     print('alert doesn\'t have valid time range, discarding')
+    #     return
 
-    if not('agency_id' in alert or 'route_id' in alert or 'trip_id' in alert or 'stop_id' in alert):
+    if not('agency_id' in alert or 'route_id' in alert or 'trip_id' in alert or 'stop_id' in alert  or 'route_type' in alert):
         print('alert doesn\'t have an affected entity, discarding')
         return
 

--- a/server/app-engine/gtfsrt.py
+++ b/server/app-engine/gtfsrt.py
@@ -140,23 +140,23 @@ def alert_is_current(alert, include_future_alerts):
     if not('time_start' in alert and 'time_stop' in alert):
         return False
     now = int(time.time())
-    # No start or stop time listed. Alert lives until deleted
+    # No start or stop time listed. Is current until deleted.
     if(alert['time_stop'] == 0 and (alert['time_stop'] == 0)):
         return True
-    # Alert started in the past
+    # Alert started in the past...
     if(int(alert['time_start']) <= now):
-        # Started in the past, no stop time. Alert lives until deleted
+        # ...with no stop time. Is current until deleted.
         if(int(alert['time_stop']) == 0):
             return True
-        # Started in the past, hasn't ended
+        # ...and hasn't hasn't ended yet. Is current until stop time.
         if(int(alert['time_stop']) > now):
             return True
-        # Started and ended in the past
+        # ...and ended in the past. Is not current.
         if(int(alert['time_stop']) < now):
             return False
-    # Alert starts in the future
+    # Alert starts in the future...
     else:
-        # Include in feed if specifically requested
+        # ...is current only if include_future_alerts passed as true (for service-alert ui)
         if(include_future_alerts == 'True'):
             return True
         else:

--- a/server/app-engine/gtfsrt.py
+++ b/server/app-engine/gtfsrt.py
@@ -309,7 +309,21 @@ def delete_alert(datastore_client, alert):
     query.add_filter('description', '=', alert["description"])
     query.add_filter('time_start', '=', alert["time_start"])
     query.add_filter('time_stop', '=', alert["time_stop"])
-    # add filter for all fields
+    if(alert["stop_id"] != ""):
+        print("filtering for stop_id...")
+        query.add_filter('stop_id', '=', alert["stop_id"])
+    if(alert["trip_id"] != None):
+        print("filtering for trip_id...")
+        query.add_filter('trip_id', '=', alert["trip_id"])
+    if(alert["route_id"] != ""):
+        print("filtering for route_id...")
+        query.add_filter('route_id', '=', alert["route_id"])
+    if(alert["agency_id"] != ""):
+        print("filtering for agency_id...")
+        query.add_filter('agency_id', '=', alert["agency_id"])
+    if(alert["route_type"] != 0):
+        print("filtering for route_type...")
+        query.add_filter('route_type', '=', alert["route_type"])
     results = list(query.fetch(limit=20))
     key_list = []
 
@@ -318,9 +332,10 @@ def delete_alert(datastore_client, alert):
         key_list.append(alert.key)
 
     print('- key_list: ' + str(key_list))
-
+    alerts_to_delete = len(key_list)
     datastore_client.delete_multi(key_list)
-    print('+ deleted alert')
+
+    print(f'+ deleted {str(alerts_to_delete)} alerts')
 
 def add_position(datastore_client, pos):
     entity = datastore.Entity(key=datastore_client.key('position'))

--- a/server/app-engine/gtfsrt.py
+++ b/server/app-engine/gtfsrt.py
@@ -140,12 +140,27 @@ def alert_is_current(alert, include_future_alerts):
     if not('time_start' in alert and 'time_stop' in alert):
         return False
     now = int(time.time())
-    if(include_future_alerts == 'True'):
-        print("include_future_alerts: " + str(include_future_alerts))
-        return now < int(alert['time_stop'])
+    # No start or stop time listed. Alert lives until deleted
+    if(alert['time_stop'] == 0 and (alert['time_stop'] == 0)):
+        return True
+    # Alert started in the past
+    if(int(alert['time_start']) <= now):
+        # Started in the past, no stop time. Alert lives until deleted
+        if(int(alert['time_stop']) == 0):
+            return True
+        # Started in the past, hasn't ended
+        if(int(alert['time_stop']) > now):
+            return True
+        # Started and ended in the past
+        if(int(alert['time_stop']) < now):
+            return False
+    # Alert starts in the future
     else:
-        print("include_future_alerts: " + str(include_future_alerts))
-        return now >= int(alert['time_start']) and now < int(alert['time_stop'])
+        # Include in feed if specifically requested
+        if(include_future_alerts == 'True'):
+            return True
+        else:
+            return False
 
 def purge_old_alerts(datastore_client):
     global last_alert_purge
@@ -312,7 +327,7 @@ def delete_alert(datastore_client, alert):
     if(alert["stop_id"] != ""):
         print("filtering for stop_id...")
         query.add_filter('stop_id', '=', alert["stop_id"])
-    if(alert["trip_id"] != None):
+    if(alert["trip_id"] != ""):
         print("filtering for trip_id...")
         query.add_filter('trip_id', '=', alert["trip_id"])
     if(alert["route_id"] != ""):
@@ -321,7 +336,7 @@ def delete_alert(datastore_client, alert):
     if(alert["agency_id"] != ""):
         print("filtering for agency_id...")
         query.add_filter('agency_id', '=', alert["agency_id"])
-    if(alert["route_type"] != 0):
+    if(alert["route_type"] != ""):
         print("filtering for route_type...")
         query.add_filter('route_type', '=', alert["route_type"])
     results = list(query.fetch(limit=20))

--- a/server/app-engine/main.py
+++ b/server/app-engine/main.py
@@ -146,6 +146,16 @@ def dispatch_ui():
     resp.headers['Last-Modified'] = util.get_mtime(fn);
     return resp
 
+@app.route('/service-alert-ui')
+def service_alert_ui():
+    print(f'{request.path}')
+
+    fn = 'static/service-alert-ui.html'
+    content = util.get_file(fn, 'r')
+    resp = Response(content, mimetype='text/html')
+    resp.headers['Last-Modified'] = util.get_mtime(fn);
+    return resp
+
 @app.route('/test')
 def test():
     fn = 'static/device-test.html'

--- a/server/app-engine/main.py
+++ b/server/app-engine/main.py
@@ -103,8 +103,10 @@ def service_alerts():
     print('/service-alerts.pb')
     agency = request.args.get('agency')
     print('- agency: ' + agency)
+    include_future_alerts = request.args.get("include_future_alerts") or "False"
+    print('- include_future_alerts: ' + include_future_alerts)
     alert_lock.acquire()
-    feed = gtfsrt.get_alert_feed(util.datastore_client, agency)
+    feed = gtfsrt.get_alert_feed(util.datastore_client, agency, include_future_alerts)
     alert_lock.release()
     return Response(feed, mimetype='application/octet-stream')
 

--- a/server/app-engine/main.py
+++ b/server/app-engine/main.py
@@ -216,6 +216,32 @@ def post_alert():
 
     return Response('{"command": "post-alert", "status": "ok"}', mimetype='application/json')
 
+@app.route('/delete-alert', methods=['POST'])
+def delete_alert():
+    print('/post-alert')
+    #print('- request.data: ' + str(request.data))
+    #print('- request.json: ' + json.dumps(request.json))
+
+    data = request.json['data'];
+    sig = request.json['sig'];
+
+    data_str = json.dumps(data,separators=(',',':'))
+    print('- data_str: ' + data_str)
+
+    agency = data['agency_key'];
+    print('- agency: ' + agency)
+
+    verified = util.verify_signature(agency, data_str, sig)
+    print('- verified: ' + str(verified))
+
+    if not verified:
+        print('*** could not verify signature for delete request, discarding')
+        return Response('{"command": "delete-alert", "status": "unverified"}', mimetype='application/json')
+
+    gtfsrt.delete_alert(util.datastore_client, data)
+
+    return Response('{"command": "delete-alert", "status": "ok"}', mimetype='application/json')
+
 """
 Determine whether or not to accept an incoming user request.
 Requests can be accepted one of two ways:

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -335,8 +335,8 @@ function handleStartStop() {
         util.log("- startMillis: " + startMillis);
         util.log("+ delta: " + (millis - startMillis));
 
-        hideElement(ALL_DROPDOWNS);
-        showElement(LOADING_TEXT_ELEMENT);
+        util.hideElement(ALL_DROPDOWNS);
+        util.showElement(LOADING_TEXT_ELEMENT);
 
         configMatrix.setSelected(CONFIG_TRIP_NAMES, false);
         configMatrix.setSelected(CONFIG_VEHICLE_IDS, false);
@@ -356,8 +356,8 @@ function handleStartStop() {
                 populateTripList(loadTrips());
             }
         } else {
-            hideElement(LOADING_TEXT_ELEMENT);
-            showElement(ALL_DROPDOWNS);
+            util.hideElement(LOADING_TEXT_ELEMENT);
+            util.showElement(ALL_DROPDOWNS);
         }
 
         if (millis - startMillis >= MAX_LIFE_MILLIS) {
@@ -370,7 +370,7 @@ function handleStartStop() {
     // Driver taps "stop", sends app to blank screen with only "Load trips" button
     else {
         clearWakeLock();
-        hideElement(TRIP_STATS_ELEMENT);
+        util.hideElement(TRIP_STATS_ELEMENT);
         util.log('- stopping position updates');
         running = false;
         let dropdowns = [TRIP_SELECT_DROPDOWN, BUS_SELECT_DROPDOWN];
@@ -456,8 +456,8 @@ function handleOkay() {
     let tripAssignmentMode = (useBulkAssignmentMode ? 'bulk' : 'manual')
     p.innerHTML = "Trip assignment mode: " + tripAssignmentMode;
 
-    hideElement(ALL_DROPDOWNS);
-    showElement(TRIP_STATS_ELEMENT);
+    util.hideElement(ALL_DROPDOWNS);
+    util.showElement(TRIP_STATS_ELEMENT);
     changeText(START_STOP_BUTTON, START_STOP_BUTTON_STOP_TEXT);
 
     util.log('- starting position updates');
@@ -886,8 +886,8 @@ function agencyIDCallback(response) {
     agencyID = response.agencyID;
     util.log("- agencyID: " + agencyID);
 
-    showElement(LOADING_TEXT_ELEMENT);
-    hideElement(QR_READER_ELEMENT);
+    util.showElement(LOADING_TEXT_ELEMENT);
+    util.hideElement(QR_READER_ELEMENT);
 
     if (agencyID === 'not found') {
         alert('could not verify client identity');
@@ -946,14 +946,14 @@ function gotConfigData(data, agencyID, arg) {
     else if (name === CONFIG_TRIP_NAMES) {
         if (useBulkAssignmentMode){
             configMatrix.setPresent(name, ConfigMatrix.NOT_PRESENT)
-            hideElement(TRIP_SELECT_DROPDOWN);
+            util.hideElement(TRIP_SELECT_DROPDOWN);
         } else {
             trips = data;
             loadTrips();
         }
     } else if (name === CONFIG_VEHICLE_IDS) {
         vehicleList = data;
-        populateList(BUS_SELECT_DROPDOWN, BUS_SELECT_DROPDOWN_TEXT, vehicleList);
+        util.populateList(BUS_SELECT_DROPDOWN, BUS_SELECT_DROPDOWN_TEXT, vehicleList);
     }
 
     configMatrix.setLoaded(name, true);
@@ -1068,36 +1068,12 @@ function gpsInterval(millis) {
     setTimeout(gpsInterval, 3000, Date.now());
 }
 
-function populateList(id, str, list) {
-    util.log("populateList()");
-    // util.log("str: " + str);
-    let p = document.getElementById(id);
-    addSelectOption(p, str, true);
-
-    list.forEach(el => addSelectOption(p, el, false));
-
-    setupListHeader(p);
-}
-
 function disableElement(id) {
     assignValue(id, 'disabled');
 }
 
 function disableElements(list) {
     list.forEach(el => disableElement(el));
-}
-
-function hideElement(id) {
-    changeDisplay(id,"none");
-}
-
-function showElement(id) {
-    changeDisplay(id,"block");
-}
-
-function changeDisplay(id,display) {
-    let p = document.getElementById(id);
-    p.style.display = display;
 }
 
 function changeText(id,text) {
@@ -1123,8 +1099,8 @@ function populateTripList(tripIDMap = tripIDLookup) {
 
     setupListHeader(p);
 
-    hideElement(LOADING_TEXT_ELEMENT);
-    showElement(ALL_DROPDOWNS);
+    util.hideElement(LOADING_TEXT_ELEMENT);
+    util.showElement(ALL_DROPDOWNS);
 }
 
 function setupListHeader(listElem) {
@@ -1137,7 +1113,7 @@ function configComplete() {
     util.log("configComplete()");
 
     vehicleIDCookie = getCookie(VEHICLE_ID_COOKIE_NAME);
-    hideElement(LOADING_TEXT_ELEMENT);
+    util.hideElement(LOADING_TEXT_ELEMENT);
 
     // If bulk assignment mode and vehicleID is already cached, simply start tracking
     if(vehicleIDCookie && useBulkAssignmentMode){
@@ -1150,7 +1126,7 @@ function configComplete() {
     }
     // If not bulk assignment mode, present the "Load trips" button.
     else{
-        showElement(START_STOP_BUTTON);
+        util.showElement(START_STOP_BUTTON);
     }
 
     setInterval(function() {

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -412,13 +412,14 @@ if (!fetch) {
         util.log("- name: " + name);
 
         currentModal = document.getElementById(name);
+        util.log("- current modal id: " + currentModal.id);
         this.showElement(name)
         currentModal.style.display = "block";
     }
 
     exports.dismissModal = function() {
         util.log("dismissModal()");
-        util.log("- currentModal: " + currentModal);
+        util.log("- dismissed modal id: " + currentModal.id);
 
         if (currentModal) {
             currentModal.style.display = "none";

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -379,4 +379,42 @@ if (!fetch) {
         listElem.options[0].disabled = true;
     }
 
+    exports.parseAgencyData = function(str) {
+        util.log("parseAgencyData()");
+        util.log("- str: " + str);
+
+        let aID = null;
+        let pem = null;
+
+        let i1 = str.indexOf(PEM_HEADER);
+        util.log("- i1: " + i1);
+
+        if (i1 > 0 && str.substring(0, i1).trim().length > 0) {
+            aID = str.substring(0, i1).trim();
+            pem = str.substring(i1);
+        }
+
+        return {
+            id: aID,
+            pem: pem
+        };
+    }
+
+    exports.handleModal = function(name) {
+        util.log("handleModal()");
+        util.log("- name: " + name);
+
+        currentModal = document.getElementById(name);
+        currentModal.style.display = "block";
+    }
+
+    exports.dismissModal = function() {
+        util.log("dismissModal()");
+        util.log("- currentModal: " + currentModal);
+
+        if (currentModal) {
+            currentModal.style.display = "none";
+            currentModal = undefined;
+        }
+    }
 }(typeof exports === 'undefined' ? this.util = {} : exports));

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -362,6 +362,10 @@ if (!fetch) {
         document.getElementById(id).value = "";
     }
 
+    exports.setElementText = function(id, text) {
+        document.getElementById(id).innerHTML = text;
+    }
+
      exports.clearSelectOptions = function(sel) {
         let l = sel.options.length - 1;
         this.log('- l: ' + l);

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -423,7 +423,7 @@ if (!fetch) {
 
     exports.dismissModal = function() {
         util.log("dismissModal()");
-        util.log("- dismissed modal id: " + currentModal.id);
+        // util.log("- dismissed modal id: " + currentModal.id);
 
         if (currentModal) {
             currentModal.style.display = "none";

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -354,6 +354,13 @@ if (!fetch) {
         sel.appendChild(opt);
     }
 
+    exports.resetDropdownSelection = function(id) {
+        document.getElementById(id).selectedIndex = 0;
+    }
+
+    exports.resetFieldValue = function(id) {
+        document.getElementById(id).value = "";
+    }
 
      exports.clearSelectOptions = function(sel) {
         let l = sel.options.length - 1;
@@ -405,6 +412,7 @@ if (!fetch) {
         util.log("- name: " + name);
 
         currentModal = document.getElementById(name);
+        this.showElement(name)
         currentModal.style.display = "block";
     }
 
@@ -416,5 +424,18 @@ if (!fetch) {
             currentModal.style.display = "none";
             currentModal = undefined;
         }
+    }
+
+    exports.hideElement = function(id) {
+        this.changeDisplay(id,"none");
+    }
+
+    exports.showElement = function(id) {
+        this.changeDisplay(id,"block");
+    }
+
+    exports.changeDisplay = function(id,display) {
+        let p = document.getElementById(id);
+        p.style.display = display;
     }
 }(typeof exports === 'undefined' ? this.util = {} : exports));

--- a/server/app-engine/static/gtfs-rt-util.js
+++ b/server/app-engine/static/gtfs-rt-util.js
@@ -345,4 +345,38 @@ if (!fetch) {
             });
         });
     };
+
+     exports.addSelectOption = function(sel, text, disabled) {
+        let opt = document.createElement('option');
+
+        opt.appendChild(document.createTextNode(text));
+        opt.disabled = disabled;
+        sel.appendChild(opt);
+    }
+
+
+     exports.clearSelectOptions = function(sel) {
+        let l = sel.options.length - 1;
+        this.log('- l: ' + l);
+
+        for(let i = l; i >= 0; i--) {
+            sel.remove(i);
+        }
+    }
+     exports.populateList = function(id, str, list) {
+        this.log("populateList()");
+        // this.log("str: " + str);
+        let p = document.getElementById(id);
+        this.addSelectOption(p, str, true);
+
+        list.forEach(el => this.addSelectOption(p, el, false));
+
+        this.setupListHeader(p);
+    }
+    exports.setupListHeader = function(listElem) {
+        listElem.selectedIndex = 0;
+        listElem.options[0].value = "disabled";
+        listElem.options[0].disabled = true;
+    }
+
 }(typeof exports === 'undefined' ? this.util = {} : exports));

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -56,7 +56,10 @@
                 <a> Header: </a>
                 <input type="text" id="header" placeholder="Short summary"> <br>
                 <a> Description: </a>
-                <input type="text" id="description" placeholder="Detailed description"> <br>
+                <form>
+                  <textarea id="description" rows="4" cols="50" placeholder="Detailed description"></textarea>
+                  <br>
+                </form>
                 <a> URL: </a>
                 <input type="text" id="url" placeholder="Optional URL with more info"> <br>
                 <label for="start-time">Start time:</label>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -22,6 +22,7 @@
         <div id="alertCreateModal" class="modal">
             <div id="form" class="modal-content">
                 <a> Select at least one entity</a><br>
+                <div id="route">
                     <input type="checkbox" id="route-checkbox" name="route-checkbox" value="Route" onclick="handleEntitySelection(this, this.id)">
                     <label for="route-checkbox"> Route</label>
                     <select id="route-select" class="entity-select" > </select>
@@ -74,21 +75,26 @@
             </div>
         </div>
         <div id="viewFeedModal" class="modal">
-            <a id="feed-view-header"> Click an alert to see detail or delete </a>
-            <canvas id="canvas"> </canvas>
+            <div class="modal-content">
+                <button type="submit" onclick="menu()"> Main Menu </button> <br>
+                <a id="feed-view-header"> Click an alert to see detail or delete </a>
+                <canvas id="canvas"> </canvas>
+            </div>
         </div>
         <div id="alertDetailModal" class="modal">
             <div class="modal-content">
-                <!-- <a id="alert-detail-header"> Alert Detail </a> -->
-                <a id="header-detail"> </a>
-                <a id="description-detail"> </a>
-                <a id="start-time-detail"> </a>
-                <a id="stop-time-detail"> </a>
                 <div id="alert-detail-buttons">
-                    <button type="submit" onclick="viewAlerts()"> Delete alert </button>
-                    <button type="submit" onclick="menu()"> Menu </button>
+                    <button type="submit" onclick="menu()"> Main Menu </button>
+                    <button type="submit" onclick="deleteAlert()"> Delete alert </button>
                     <button type="submit" onclick="viewAlerts()"> Back to feed </button>
                 </div>
+                <!-- <a id="alert-detail-header"> Alert Detail </a> -->
+                <a id="header-detail"> </a> <br>
+                <a id="description-detail"> </a> <br>
+                <a id="cause-detail"> </a> <br>
+                <a id="effect-detail"> </a> <br>
+                <a id="start-time-detail"> </a> <br>
+                <a id="stop-time-detail"> </a> <br>
             </div>
         </div>
         <script src="../static/gtfs-rt-util.js"></script>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -61,7 +61,7 @@
                 <input type="text" id="url" placeholder="Optional URL with more info"> <br>
                 <label for="start-time">Start time:</label>
                 <input type="datetime-local" id="start-time" name="start-time" value="2022-01-01T08:00" min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
-                <label for="stop-time">End time:</label>
+                <label for="stop-time">Stop time:</label>
                 <input type="datetime-local" id="stop-time" value="2023-01-01T08:00" name="stop-time" min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
                 <a> Cause: </a>
                 <select id="cause-select"> </select> <br>
@@ -82,19 +82,10 @@
                 <button type="submit" onclick="menu()"> Menu </button>
                 <button type="submit" onclick="viewAlerts()"> Back to feed </button> <br>
                 <!-- <a id="alert-detail-header"> Alert Detail </a> -->
-                <ul style="list-style-type:none;">
-                    <li> Affected entities: </li>
-                    <li id="agency-id-detail" class="entity-detail"> </li>
-                    <li id="route-id-detail" class="entity-detail"> </li>
-                    <li id="trip-id-detail" class="entity-detail"> </li>
-                    <li id="stop-id-detail" class="entity-detail"> </li>
-                    <li id="route-type-detail" class="entity-detail"> </li>
-                    <li id="header-detail"> </li>
-                    <li id="description-detail"> </li>
-                    <li id="cause-detail"> </li>
-                    <li id="effect-detail"> </li>
-                    <li id="start-time-detail"> </li>
-                    <li id="stop-time-detail"> </li>
+                <a> Affected entities: </a>
+                <ul id="affected-entities">
+                </ul>
+                <ul id="alert-detail-list" style="list-style-type:none; padding-left: 0;">
                 </ul>
                 <button type="submit" onclick="deleteAlert()"> Delete alert </button>
             </div>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -1,7 +1,9 @@
 <html>
     <head>
-
         <link type="text/css" rel="stylesheet" href="../static/service-alert-ui.css">
+        <script src="../static/protobuf.min.js"> </script>
+        <script src="../static/alert-proto.browser.js"> </script>
+        <script src="../static/pbf.js"> </script>
     </head>
     <body>
         <div id="keyEntryModal" class="modal">
@@ -11,15 +13,65 @@
             <button id="key-okay" onclick="handleKey(this.id)" type="submit" class="btn" style="background-color: blue">Okay</button>
           </div>
         </div>
-        <div id="form">
-            <select id="entity-select" onchange="handleEntityChoice()"> </select>
-            <select id="item-select"> </select>
-            <input type="text" id="description">
-            <input type="text" id="header">
-            <input type="text" id="url">
-            <select id="cause-select"> </select>
-            <select id="effect-select"> </select>
-            <button type="submit" id="submit" onclick="postServiceAlert()"> Submit </button>
+        <div id="menuModal" class="modal">
+            <div class="modal-content">
+                <button id="create-alert-button" onclick="handleNavigation(this.id)"> Create alert</button>
+                <button id="view-alerts-button" onclick="handleNavigation(this.id)"> View/edit alerts</button>
+            </div>
+        </div>
+        <div id="alertCreateModal" class="modal">
+            <div id="form" class="modal-content">
+                <a> Select at least one entity</a><br>
+                    <input type="checkbox" id="route-checkbox" name="route-checkbox" value="Route" onclick="handleEntitySelection(this, this.id)">
+                    <label for="route-checkbox"> Route</label>
+                    <select id="route-select" class="entity-select" > </select>
+                    <br>
+                </div>
+                <div id="trip">
+                    <input type="checkbox" id="trip-checkbox" name="trip-checkbox" value="Trip" onclick="handleEntitySelection(this, this.id)">
+                    <label for="trip-checkbox"> Trip</label>
+                    <select id="trip-select" class="entity-select"> </select>
+                    <br>
+                </div>
+                <div id="stop">
+                    <input type="checkbox" id="stop-checkbox" name="stop-checkbox" value="Stop" onclick="handleEntitySelection(this, this.id)">
+                    <label for="stop-checkbox"> Stop</label>
+                    <select id="stop-select" class="entity-select" style=""> </select>
+                    <br>
+                </div>
+                <div id="route-type">
+                    <input type="checkbox" id="route-type-checkbox" name="route-type-checkbox" value="Route type" onclick="handleEntitySelection(this, this.id)">
+                    <label for="route-type-checkbox"> Route type</label>
+                    <select id="route-type-select" class="entity-select"> </select>
+                    <br>
+                </div>
+                <div id="agency">
+                    <input type="checkbox" id="agency-checkbox" name="agency-checkbox" value="Agency" onclick="handleEntitySelection(this, this.id)">
+                    <label for="agency-checkbox"> Agency</label>
+                    <select id="agency-select" class="entity-select"> </select>
+                    <br>
+                </div>
+                <a> Header: </a>
+                <input type="text" id="header" placeholder="Short summary"> <br>
+                <a> Description: </a>
+                <input type="text" id="description" placeholder="Detailed description"> <br>
+                <a> URL: </a>
+                <input type="text" id="url" placeholder="Optional URL with more info"> <br>
+                <label for="start-time">Start time:</label>
+                <input type="datetime-local" id="start-time"
+                       name="start-time"
+                       min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
+                <label for="stop-time">End time:</label>
+                <input type="datetime-local" id="stop-time"
+                       name="stop-time"
+                       min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
+                <a> Cause: </a>
+                <select id="cause-select"> </select> <br>
+                <a> Effect: </a>
+                <select id="effect-select"> </select> <br>
+                <button type="submit" id="submit" onclick="postServiceAlert()"> Submit </button>
+                <button type="submit" id="menu" onclick="handleNavigation(this.id)"> Menu </button> <br>
+            </div>
         </div>
         <script src="../static/gtfs-rt-util.js"></script>
         <script src="../static/service-alert-ui.js"></script>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -15,8 +15,8 @@
         </div>
         <div id="menuModal" class="modal">
             <div class="modal-content">
-                <button id="create-alert-button" onclick="handleNavigation(this.id)"> Create alert</button>
-                <button id="view-alerts-button" onclick="handleNavigation(this.id)"> View/edit alerts</button>
+                <button id="create-alert-button" onclick="createAlert()"> Create alert</button>
+                <button id="view-alerts-button" onclick="viewAlerts()"> View/edit alerts</button>
             </div>
         </div>
         <div id="alertCreateModal" class="modal">
@@ -69,8 +69,26 @@
                 <select id="cause-select"> </select> <br>
                 <a> Effect: </a>
                 <select id="effect-select"> </select> <br>
-                <button type="submit" id="submit" onclick="postServiceAlert()"> Submit </button>
-                <button type="submit" id="menu" onclick="handleNavigation(this.id)"> Menu </button> <br>
+                <button type="submit" id="submit-alert-button" onclick="postServiceAlert()"> Submit </button>
+                <button type="submit" id="alert-create-menu" onclick="menu()"> Menu </button> <br>
+            </div>
+        </div>
+        <div id="viewFeedModal" class="modal">
+            <a id="feed-view-header"> Click an alert to see detail or delete </a>
+            <canvas id="canvas"> </canvas>
+        </div>
+        <div id="alertDetailModal" class="modal">
+            <div class="modal-content">
+                <!-- <a id="alert-detail-header"> Alert Detail </a> -->
+                <a id="header-detail"> </a>
+                <a id="description-detail"> </a>
+                <a id="start-time-detail"> </a>
+                <a id="stop-time-detail"> </a>
+                <div id="alert-detail-buttons">
+                    <button type="submit" onclick="viewAlerts()"> Delete alert </button>
+                    <button type="submit" onclick="menu()"> Menu </button>
+                    <button type="submit" onclick="viewAlerts()"> Back to feed </button>
+                </div>
             </div>
         </div>
         <script src="../static/gtfs-rt-util.js"></script>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -16,38 +16,39 @@
         <div id="menuModal" class="modal">
             <div class="modal-content">
                 <button id="create-alert-button" onclick="createAlert()"> Create alert</button>
-                <button id="view-alerts-button" onclick="viewAlerts()"> View/edit alerts</button>
+                <button id="view-alerts-button" onclick="viewAlerts()"> View/delete alerts</button>
             </div>
         </div>
         <div id="alertCreateModal" class="modal">
             <div id="form" class="modal-content">
-                <a> Select at least one entity</a><br>
+                <button type="submit" id="alert-create-menu" onclick="menu()"> Menu </button> <br>
+                <a> Select at least one entity:</a><br>
                 <div id="route">
-                    <input type="checkbox" id="route-checkbox" name="route-checkbox" value="Route" onclick="handleEntitySelection(this, this.id)">
+                    <input type="checkbox" id="route-checkbox" name="route-checkbox" value="Route" onclick="handleEntitySelection(this)">
                     <label for="route-checkbox"> Route</label>
                     <select id="route-select" class="entity-select" > </select>
                     <br>
                 </div>
                 <div id="trip">
-                    <input type="checkbox" id="trip-checkbox" name="trip-checkbox" value="Trip" onclick="handleEntitySelection(this, this.id)">
+                    <input type="checkbox" id="trip-checkbox" name="trip-checkbox" value="Trip" onclick="handleEntitySelection(this)">
                     <label for="trip-checkbox"> Trip</label>
                     <select id="trip-select" class="entity-select"> </select>
                     <br>
                 </div>
                 <div id="stop">
-                    <input type="checkbox" id="stop-checkbox" name="stop-checkbox" value="Stop" onclick="handleEntitySelection(this, this.id)">
+                    <input type="checkbox" id="stop-checkbox" name="stop-checkbox" value="Stop" onclick="handleEntitySelection(this)">
                     <label for="stop-checkbox"> Stop</label>
                     <select id="stop-select" class="entity-select" style=""> </select>
                     <br>
                 </div>
                 <div id="route-type">
-                    <input type="checkbox" id="route-type-checkbox" name="route-type-checkbox" value="Route type" onclick="handleEntitySelection(this, this.id)">
+                    <input type="checkbox" id="route-type-checkbox" name="route-type-checkbox" value="Route type" onclick="handleEntitySelection(this)">
                     <label for="route-type-checkbox"> Route type</label>
                     <select id="route-type-select" class="entity-select"> </select>
                     <br>
                 </div>
                 <div id="agency">
-                    <input type="checkbox" id="agency-checkbox" name="agency-checkbox" value="Agency" onclick="handleEntitySelection(this, this.id)">
+                    <input type="checkbox" id="agency-checkbox" name="agency-checkbox" value="Agency" onclick="handleEntitySelection(this)">
                     <label for="agency-checkbox"> Agency</label>
                     <select id="agency-select" class="entity-select"> </select>
                     <br>
@@ -59,42 +60,43 @@
                 <a> URL: </a>
                 <input type="text" id="url" placeholder="Optional URL with more info"> <br>
                 <label for="start-time">Start time:</label>
-                <input type="datetime-local" id="start-time"
-                       name="start-time"
-                       min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
+                <input type="datetime-local" id="start-time" name="start-time" value="2022-01-01T08:00" min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
                 <label for="stop-time">End time:</label>
-                <input type="datetime-local" id="stop-time"
-                       name="stop-time"
-                       min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
+                <input type="datetime-local" id="stop-time" value="2023-01-01T08:00" name="stop-time" min="2022-01-01T08:00" max="2099-12-31T08:00"> <br>
                 <a> Cause: </a>
                 <select id="cause-select"> </select> <br>
                 <a> Effect: </a>
                 <select id="effect-select"> </select> <br>
                 <button type="submit" id="submit-alert-button" onclick="postServiceAlert()"> Submit </button>
-                <button type="submit" id="alert-create-menu" onclick="menu()"> Menu </button> <br>
             </div>
         </div>
         <div id="viewFeedModal" class="modal">
             <div class="modal-content">
-                <button type="submit" onclick="menu()"> Main Menu </button> <br>
+                <button type="submit" onclick="menu()"> Menu </button> <br>
                 <a id="feed-view-header"> Click an alert to see detail or delete </a>
                 <canvas id="canvas"> </canvas>
             </div>
         </div>
         <div id="alertDetailModal" class="modal">
             <div class="modal-content">
-                <div id="alert-detail-buttons">
-                    <button type="submit" onclick="menu()"> Main Menu </button>
-                    <button type="submit" onclick="deleteAlert()"> Delete alert </button>
-                    <button type="submit" onclick="viewAlerts()"> Back to feed </button>
-                </div>
+                <button type="submit" onclick="menu()"> Menu </button>
+                <button type="submit" onclick="viewAlerts()"> Back to feed </button> <br>
                 <!-- <a id="alert-detail-header"> Alert Detail </a> -->
-                <a id="header-detail"> </a> <br>
-                <a id="description-detail"> </a> <br>
-                <a id="cause-detail"> </a> <br>
-                <a id="effect-detail"> </a> <br>
-                <a id="start-time-detail"> </a> <br>
-                <a id="stop-time-detail"> </a> <br>
+                <ul style="list-style-type:none;">
+                    <li> Affected entities: </li>
+                    <li id="agency-id-detail" class="entity-detail"> </li>
+                    <li id="route-id-detail" class="entity-detail"> </li>
+                    <li id="trip-id-detail" class="entity-detail"> </li>
+                    <li id="stop-id-detail" class="entity-detail"> </li>
+                    <li id="route-type-detail" class="entity-detail"> </li>
+                    <li id="header-detail"> </li>
+                    <li id="description-detail"> </li>
+                    <li id="cause-detail"> </li>
+                    <li id="effect-detail"> </li>
+                    <li id="start-time-detail"> </li>
+                    <li id="stop-time-detail"> </li>
+                </ul>
+                <button type="submit" onclick="deleteAlert()"> Delete alert </button>
             </div>
         </div>
         <script src="../static/gtfs-rt-util.js"></script>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+
+    </head>
+    <body>
+        <script src="./gtfs-rt-util.js"></script>
+        <script src="./service-alert-ui.js"></script>
+    </body>
+</html>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -3,6 +3,8 @@
 
     </head>
     <body>
+        <select id="category-select" onchange="handleCategoryChoice()"> </select>
+        <select id="item-select"> </select>
         <script src="./gtfs-rt-util.js"></script>
         <script src="./service-alert-ui.js"></script>
     </body>

--- a/server/app-engine/static/service-alert-ui.html
+++ b/server/app-engine/static/service-alert-ui.html
@@ -1,11 +1,27 @@
 <html>
     <head>
 
+        <link type="text/css" rel="stylesheet" href="../static/service-alert-ui.css">
     </head>
     <body>
-        <select id="category-select" onchange="handleCategoryChoice()"> </select>
-        <select id="item-select"> </select>
-        <script src="./gtfs-rt-util.js"></script>
-        <script src="./service-alert-ui.js"></script>
+        <div id="keyEntryModal" class="modal">
+          <div class="modal-content">
+            <p id="key-title" style="text-align: center">Enter Key</p>
+            <textarea id="keyTextArea" rows="5"></textarea>
+            <button id="key-okay" onclick="handleKey(this.id)" type="submit" class="btn" style="background-color: blue">Okay</button>
+          </div>
+        </div>
+        <div id="form">
+            <select id="entity-select" onchange="handleEntityChoice()"> </select>
+            <select id="item-select"> </select>
+            <input type="text" id="description">
+            <input type="text" id="header">
+            <input type="text" id="url">
+            <select id="cause-select"> </select>
+            <select id="effect-select"> </select>
+            <button type="submit" id="submit" onclick="postServiceAlert()"> Submit </button>
+        </div>
+        <script src="../static/gtfs-rt-util.js"></script>
+        <script src="../static/service-alert-ui.js"></script>
     </body>
 </html>

--- a/server/app-engine/static/service-alert-ui.js
+++ b/server/app-engine/static/service-alert-ui.js
@@ -175,21 +175,21 @@ async function loadAlerts(){
   util.log("JSON.stringify(feed): " + JSON.stringify(feed));
     // Add all the locations to the map:
   alerts = await feed.map(feedObject => {
-    let alert = feedObject.alert;
+    let a = feedObject.alert;
     let alertObject = new Object({
       id: feedObject.id,
-      time_start: alert.active_period[0].start,
-      time_stop: alert.active_period[0].end,
-      agency_id: alert.informed_entity[0].agency_id,
-      trip_id: (alert.informed_entity[0].trip !== null ? alert.informed_entity[0].trip.trip_id: null),
-      stop_id: alert.informed_entity[0].stop_id,
-      route_id: alert.informed_entity[0].route_id,
-      route_type: alert.informed_entity[0].route_type,
-      cause: causes.get(alert.cause),
-      effect: effects.get(alert.effect),
-      header: alert.header_text.translation[0].text,
-      description: alert.description_text.translation[0].text,
-      url: (alert.url !== null ? alert.url.translation[0].text : null)
+      time_start: a.active_period[0].start,
+      time_stop: a.active_period[0].end,
+      agency_id: a.informed_entity[0].agency_id,
+      trip_id: (a.informed_entity[0].trip !== null ? a.informed_entity[0].trip.trip_id: null),
+      stop_id: a.informed_entity[0].stop_id,
+      route_id: a.informed_entity[0].route_id,
+      route_type: a.informed_entity[0].route_type,
+      cause: causes.get(a.cause),
+      effect: effects.get(a.effect),
+      header: a.header_text.translation[0].text,
+      description: a.description_text.translation[0].text,
+      url: (a.url !== null ? a.url.translation[0].text : null)
     });
 
     alertObject.time_start_formatted = (new Date(alertObject.time_start * 1000)).toLocaleString();
@@ -249,6 +249,7 @@ function deleteAlert(){
   };
 
   util.signAndPost(data, signatureKey, '/delete-alert', document);
+  alert("Alert deleted");
   resetCanvas();
   menu();
 }
@@ -448,16 +449,21 @@ function createLayout(){
   let yy = SPACING;
   let xx = SPACING;
   let colNum = 1;
-  for (alert of alerts){
-    alert.y = yy;
-    alert.x = xx;
-    let textRows = ALERT_ROWS + alert.num_entities;
+  let maxBoxHeight = 0;
+  for (let i=0; i<alerts.length; i++){
+    alerts[i].y = yy;
+    alerts[i].x = xx;
+    let textRows = ALERT_ROWS + alerts[i].num_entities;
     let box_height = textRows * FONT_SIZE;
+    maxBoxHeight = Math.max(box_height, maxBoxHeight);
     if(colNum < alertsPerRow){
       xx += BOX_WIDTH + SPACING;
       colNum +=1;
+      if(i === alerts.length-1){
+        yy += maxBoxHeight + SPACING;
+      }
     } else{
-      yy += box_height + SPACING;
+      yy += maxBoxHeight + SPACING;
       colNum = 1;
       xx = SPACING;
     }
@@ -484,15 +490,15 @@ async function feedView(){
 }
 
 function drawAlerts(){
-  for (alert of alerts){
+  for (let a of alerts){
     ctx.beginPath();
     ctx.strokeStyle = "black";
     ctx.fillStyle = "white";
 
-    let rows = ALERT_ROWS + alert.num_entities;
+    let rows = ALERT_ROWS + a.num_entities;
     let box_height = rows * FONT_SIZE;
-    ctx.fillRect(alert.x, alert.y, BOX_WIDTH, box_height);
-    ctx.rect(alert.x, alert.y, BOX_WIDTH, box_height);
+    ctx.fillRect(a.x, a.y, BOX_WIDTH, box_height);
+    ctx.rect(a.x, a.y, BOX_WIDTH, box_height);
     ctx.stroke();
 
     ctx.fillStyle = "black";
@@ -500,32 +506,32 @@ function drawAlerts(){
     ctx.font = FONT_BOLD;
 
     let i = -1;
-    ctx.fillText("This alert applies to:", alert.x, alert.y + FONT_SIZE * ++i);
+    ctx.fillText("This alert applies to:", a.x, a.y + FONT_SIZE * ++i);
     ctx.font = FONT_NORMAL;
-    if(alert.agency_id !== ""){
-      ctx.fillText(` - AgencyID: ${alert.agency_id}`, alert.x, alert.y + FONT_SIZE * ++i)
+    if(a.agency_id !== ""){
+      ctx.fillText(` - AgencyID: ${a.agency_id}`, a.x, a.y + FONT_SIZE * ++i)
     }
-    if(alert.trip_id !== null){
-      ctx.fillText(` - TripID: ${alert.trip_id}`, alert.x, alert.y + FONT_SIZE * ++i)
+    if(a.trip_id !== null){
+      ctx.fillText(` - TripID: ${a.trip_id}`, a.x, a.y + FONT_SIZE * ++i)
     }
-    if(alert.stop_id !== ""){
-      ctx.fillText(` - StopID: ${alert.stop_id}`, alert.x, alert.y + FONT_SIZE * ++i)
+    if(a.stop_id !== ""){
+      ctx.fillText(` - StopID: ${a.stop_id}`, a.x, a.y + FONT_SIZE * ++i)
     }
-    if(alert.route_id !== ""){
-      ctx.fillText(` - RouteID: ${alert.route_id}`, alert.x, alert.y + FONT_SIZE * ++i)
+    if(a.route_id !== ""){
+      ctx.fillText(` - RouteID: ${a.route_id}`, a.x, a.y + FONT_SIZE * ++i)
     }
-    if(alert.route_type !== 0){
-      ctx.fillText(` - Route type: ${alert.route_type}`, alert.x, alert.y + FONT_SIZE * ++i)
+    if(a.route_type !== 0){
+      ctx.fillText(` - Route type: ${a.route_type}`, a.x, a.y + FONT_SIZE * ++i)
     }
     ctx.font = FONT_BOLD;
-    ctx.fillText("Alert details:", alert.x, alert.y + FONT_SIZE * ++i);
+    ctx.fillText("Alert details:", a.x, a.y + FONT_SIZE * ++i);
     ctx.font = FONT_NORMAL;
-    ctx.fillText(`Header: ${alert.header}`, alert.x, alert.y + FONT_SIZE * ++i)
-    ctx.fillText(`Description: ${alert.description}`, alert.x, alert.y + FONT_SIZE * ++i)
-    ctx.fillText(`Start time: ${alert.time_start_formatted}`, alert.x, alert.y + FONT_SIZE * ++i)
-    ctx.fillText(`Stop time: ${alert.time_stop_formatted}`, alert.x, alert.y + FONT_SIZE * ++i)
-    ctx.fillText(`Cause: ${alert.cause}`, alert.x, alert.y + FONT_SIZE * ++i)
-    ctx.fillText(`Effect: ${alert.effect}`, alert.x, alert.y + FONT_SIZE * ++i)
+    ctx.fillText(`Header: ${a.header}`, a.x, a.y + FONT_SIZE * ++i)
+    ctx.fillText(`Description: ${a.description}`, a.x, a.y + FONT_SIZE * ++i)
+    ctx.fillText(`Start time: ${a.time_start_formatted}`, a.x, a.y + FONT_SIZE * ++i)
+    ctx.fillText(`Stop time: ${a.time_stop_formatted}`, a.x, a.y + FONT_SIZE * ++i)
+    ctx.fillText(`Cause: ${a.cause}`, a.x, a.y + FONT_SIZE * ++i)
+    ctx.fillText(`Effect: ${a.effect}`, a.x, a.y + FONT_SIZE * ++i)
   }
 }
 
@@ -535,11 +541,11 @@ document.body.addEventListener('click', function(event) {
     let searchX = event.pageX;
     let searchY = event.pageY - feedViewHeaderHeight;
 
-    for (alert of alerts){
+    for (let a of alerts){
       util.log("searching...");
-      if(objectContainsPoint(alert, searchX, searchY)){
-        selectedAlert = alert;
-        alertDetailView(alert);
+      if(objectContainsPoint(a, searchX, searchY)){
+        selectedAlert = a;
+        alertDetailView(a);
       }
     }
   }
@@ -549,7 +555,7 @@ function objectContainsPoint(object, x, y){
     return (x > object.x
           && x < object.x + BOX_WIDTH
           && y > object.y
-          && y < object.y + (ALERT_ROWS + alert.num_entities) * FONT_SIZE
+          && y < object.y + (ALERT_ROWS + object.num_entities) * FONT_SIZE
           )
 }
 

--- a/server/app-engine/static/service-alert-ui.js
+++ b/server/app-engine/static/service-alert-ui.js
@@ -1,0 +1,51 @@
+const fileMap = new Map();
+const files = ["trips", "routes", "stops"];
+
+const agencyID = 'santa-ynez-valley-transit';
+const baseURL = `https://storage.googleapis.com/graas-resources/gtfs-archive/${agencyID}/`;
+
+for (let i = 0; i < files.length; i++) {
+  let fileName = files[i];
+  let url = baseURL + fileName + ".txt";
+  util.log('- fetching from ' + url);
+  util.timedFetch(url, {
+      method: 'GET'
+  })
+  .then(function(response) {
+      response.text().then(function(text){
+        fileMap.set(fileName,csvToArray(text));
+      })
+  })
+  .catch((error) => {
+      util.log('*** fetch() error: ' + error);
+  });
+}
+
+util.log(fileMap.get("trips"));
+
+function csvToArray(str, delimiter = ",") {
+  // slice from start of text to the first \n index
+  // use split to create an array from string by delimiter
+  const headers = str.slice(0, str.indexOf("\n")).split(delimiter);
+
+  // slice from \n index + 1 to the end of the text
+  // use split to create an array of each csv value row
+  const rows = str.slice(str.indexOf("\n") + 1).split("\n");
+
+  // Map the rows
+  // split values from each row into an array
+  // use headers.reduce to create an object
+  // object properties derived from headers:values
+  // the object passed as an element of the array
+  const arr = rows.map(function (row) {
+    const values = row.split(delimiter);
+    const el = headers.reduce(function (object, header, index) {
+      object[header] = values[index];
+      return object;
+    }, {});
+    return el;
+  });
+
+  // return the array
+  return arr;
+}

--- a/server/app-engine/static/service-alert-ui.js
+++ b/server/app-engine/static/service-alert-ui.js
@@ -345,9 +345,9 @@ function populateDropdowns(){
   }
   util.populateList("cause-select", "Select an alert cause", Array.from(causes.values()));
   util.populateList("effect-select", "Select an alert effect", Array.from(effects.values()));
-  util.populateList("route-select", "Select a route", getItems("routes", "route_id"));
-  util.populateList("trip-select", "Select a trip", getItems("trips", "trip_id"));
-  util.populateList("stop-select", "Select a stop", getItems("stops", "stop_id"));
+  util.populateList("route-select", "Select a Route ID", getItems("routes", "route_id"));
+  util.populateList("trip-select", "Select a Trip ID", getItems("trips", "trip_id"));
+  util.populateList("stop-select", "Select a Stop ID", getItems("stops", "stop_id"));
 }
 
 function getItems(type, columnName){
@@ -519,14 +519,16 @@ function drawAlerts(){
     let entityLines = [];
     alertEntities.forEach((value, key) => {
       if(a[key] !== ""){
-        entityLines.push(` - ${value}: ${a[key]}`);
+        let str = ` - ${value}: ${a[key]}`
+        entityLines.push(str);
       }
     });
 
     let attributeLines = [];
     alertFields.forEach((value, key) => {
       if(a[key] !== ""){
-        let str = attributeLines.push(`${value}: ${a[key]}`);
+        let str = `${value}: ${a[key]}`;
+        attributeLines.push(str);
       }
     });
 
@@ -535,7 +537,7 @@ function drawAlerts(){
     ctx.font = FONT_NORMAL;
 
     for(let line of entityLines){
-      ctx.fillText(line, a.x, a.y + FONT_SIZE * ++i)
+      ctx.fillText(shortenFeedStringIfNeeded(line), a.x, a.y + FONT_SIZE * ++i)
     }
 
     ctx.font = FONT_BOLD;
@@ -543,7 +545,7 @@ function drawAlerts(){
     ctx.font = FONT_NORMAL;
 
     for(let line of attributeLines){
-      ctx.fillText(line, a.x, a.y + FONT_SIZE * ++i)
+      ctx.fillText(shortenFeedStringIfNeeded(line), a.x, a.y + FONT_SIZE * ++i)
     }
 
   }
@@ -565,6 +567,17 @@ document.body.addEventListener('click', function(event) {
   }
 });
 
+function shortenFeedStringIfNeeded(string){
+  if(ctx.measureText(string).width > BOX_WIDTH){
+    return shortenFeedString(string) + "...";
+  } else return string;
+}
+
+function shortenFeedString(string){
+  if(ctx.measureText(string + "...").width > BOX_WIDTH){
+    return shortenFeedString(string.slice(0,-1))
+  } else return string;
+}
 function objectContainsPoint(object, x, y){
     return (x > object.x
           && x < object.x + BOX_WIDTH

--- a/server/app-engine/static/service-alert-ui.js
+++ b/server/app-engine/static/service-alert-ui.js
@@ -14,6 +14,7 @@ for (let i = 0; i < files.length; i++) {
   .then(function(response) {
       response.text().then(function(text){
         fileMap.set(fileName,csvToArray(text));
+        if(fileMap.size === files.length) start();
       })
   })
   .catch((error) => {
@@ -21,8 +22,23 @@ for (let i = 0; i < files.length; i++) {
   });
 }
 
-util.log(fileMap.get("trips"));
+function start(){
+  util.log(fileMap);
+  util.populateList("category-select", "Select an alert category", files);
+}
 
+function handleCategoryChoice(){
+  let categorySelect = document.getElementById("category-select");
+  let category = categorySelect.value;
+  let categorySingular = category.slice(0,-1);
+  let id = categorySingular + "_id";
+  util.log(fileMap.get(category));
+  var idArray = fileMap.get(category).map(function (el) { return el[id]; });
+  util.clearSelectOptions(document.getElementById("item-select"));
+  util.populateList("item-select", "Select a " + categorySingular, idArray);
+}
+
+// Thanks to: https://www.bennadel.com/blog/1504-ask-ben-parsing-csv-strings-with-javascript-exec-regular-expression-command.htm
 function csvToArray(str, delimiter = ",") {
   // slice from start of text to the first \n index
   // use split to create an array from string by delimiter
@@ -31,7 +47,6 @@ function csvToArray(str, delimiter = ",") {
   // slice from \n index + 1 to the end of the text
   // use split to create an array of each csv value row
   const rows = str.slice(str.indexOf("\n") + 1).split("\n");
-
   // Map the rows
   // split values from each row into an array
   // use headers.reduce to create an object
@@ -47,5 +62,6 @@ function csvToArray(str, delimiter = ",") {
   });
 
   // return the array
-  return arr;
+  // (hacky scott fix for null last row added)
+  return arr.slice(0,-1);
 }

--- a/server/app-engine/static/service-alert-ui.js
+++ b/server/app-engine/static/service-alert-ui.js
@@ -1,8 +1,35 @@
+const PEM_HEADER = "-----BEGIN TOKEN-----";
+const PEM_FOOTER = "-----END TOKEN-----";
+var signatureKey = null;
+var currentModal = null;
 const fileMap = new Map();
 const files = ["trips", "routes", "stops"];
+const causes = ["Unknown cause",
+                "Other cause",
+                "Technical problem",
+                "Strike",
+                "Demonstration",
+                "Accident",
+                "Holiday",
+                "Weather",
+                "Maintenance",
+                "Construction",
+                "Police activity",
+                "Medical emergency"];
+const effects = ["No service",
+                "Reduced service",
+                "Significant delays",
+                "Detour",
+                "Additional service",
+                "Modified service",
+                "Stop moved",
+                "Other effect",
+                "Unknown effect"];
 
-const agencyID = 'santa-ynez-valley-transit';
+var agencyID = 'pr-test';
 const baseURL = `https://storage.googleapis.com/graas-resources/gtfs-archive/${agencyID}/`;
+
+initialize();
 
 for (let i = 0; i < files.length; i++) {
   let fileName = files[i];
@@ -22,21 +49,132 @@ for (let i = 0; i < files.length; i++) {
   });
 }
 
-function start(){
-  util.log(fileMap);
-  util.populateList("category-select", "Select an alert category", files);
+function initialize(){
+  let str = localStorage.getItem("app-data") || "";
+
+  if (!str) {
+    util.handleModal("keyEntryModal");
+  }
+  else {
+    completeInitialization(util.parseAgencyData(str));
+  }
 }
 
-function handleCategoryChoice(){
-  let categorySelect = document.getElementById("category-select");
-  let category = categorySelect.value;
-  let categorySingular = category.slice(0,-1);
-  let id = categorySingular + "_id";
-  util.log(fileMap.get(category));
-  var idArray = fileMap.get(category).map(function (el) { return el[id]; });
-  util.clearSelectOptions(document.getElementById("item-select"));
-  util.populateList("item-select", "Select a " + categorySingular, idArray);
+async function completeInitialization(agencyData) {
+    agencyID = agencyData.id;
+    util.log("- agencyID: " + agencyID);
+
+    let pem = agencyData.pem;
+
+    let i1 = pem.indexOf(PEM_HEADER);
+    util.log("- i1: " + i1);
+
+    let i2 = pem.indexOf(PEM_FOOTER);
+    util.log("- i2: " + i2);
+
+    let b64 = pem.substring(i1 + PEM_HEADER.length, i2);
+    // util.log("- b64: " + b64);
+
+    keyType = "ECDSA";
+    keyLength = 256;
+
+    let key = atob(b64);
+    // util.log("- key.length: " + key.length);
+
+    const binaryDer = util.str2ab(key);
+
+    signatureKey = await crypto.subtle.importKey(
+        "pkcs8",
+        binaryDer,
+        {
+            name: "ECDSA",
+            namedCurve: "P-256"
+        },
+        false,
+        ["sign"]
+    );
+
+    util.log("- signatureKey.type: " + signatureKey.type);
 }
+
+function handleKey(id) {
+  util.log('handleKey()');
+  util.log('- id: ' + id);
+
+  let dateStr;
+
+  let p = document.getElementById('keyTextArea');
+  let value = p.value.replace(/\n/g, "");
+  util.log("- value: " + value);
+
+  let i1 = value.indexOf(PEM_HEADER);
+  util.log("- i1: " + i1);
+
+  let i2 = value.indexOf(PEM_FOOTER);
+  util.log("- i2: " + i2);
+
+  if (i1 === 0) {
+      alert('missing agency id');
+      return;
+  } else if (i1 < 0 || i2 < 0) {
+      alert('not a valid key');
+      return;
+  }
+
+  util.dismissModal();
+  p.value = "";
+
+  localStorage.setItem('app-data', value);
+  completeInitialization(util.parseAgencyData(value));
+}
+
+// todo: rename
+function start(){
+  util.log(fileMap);
+  util.populateList("entity-select", "Select an alert entity", files);
+  util.populateList("cause-select", "Select an alert cause", causes);
+  util.populateList("effect-select", "Select an alert effect", effects);
+}
+
+function handleEntityChoice(){
+  let entitySelect = document.getElementById("entity-select");
+  let entity = entitySelect.value;
+  let entitySingular = entity.slice(0,-1);
+  let id = entitySingular + "_id";
+  util.log(fileMap.get(entity));
+  var idArray = fileMap.get(entity).map(function (el) { return el[id]; });
+  util.clearSelectOptions(document.getElementById("item-select"));
+  util.populateList("item-select", "Select a " + entitySingular, idArray);
+}
+
+function postServiceAlert() {
+    util.log('handleGPSUpdate()');
+    let timestamp = Math.floor(Date.now() / 1000);
+    let cause = document.getElementById("cause-select").value;
+    let effect = document.getElementById("effect-select").value;
+    let description = document.getElementById("description").value;
+    let header = document.getElementById("header").value;
+    // TODO: add URL
+    let url = document.getElementById("url").value;
+
+    let data = {
+        agency_key: agencyID,
+        cause: cause,
+        description: description,
+        effect: effect,
+        header: header,
+        time_stamp: timestamp,
+        // time_start: time_start,
+        // time_stop: time_stop
+    };
+
+    util.log("data.cause: " + data.cause);
+    util.log("data.effect: " + data.effect);
+    util.log("data.header: " + data.header);
+    util.log("data.time_stamp: " + data.time_stamp);
+    util.signAndPost(data, signatureKey, '/post-alert', document);
+}
+
 
 // Thanks to: https://www.bennadel.com/blog/1504-ask-ben-parsing-csv-strings-with-javascript-exec-regular-expression-command.htm
 function csvToArray(str, delimiter = ",") {

--- a/server/app-engine/static/service-alert-ui.js
+++ b/server/app-engine/static/service-alert-ui.js
@@ -1,59 +1,97 @@
+
+const serverURL = "https://127.0.0.1:8080/";
 const PEM_HEADER = "-----BEGIN TOKEN-----";
 const PEM_FOOTER = "-----END TOKEN-----";
 var signatureKey = null;
 var currentModal = null;
+var agencyID = null;
 const fileMap = new Map();
-const files = ["trips", "routes", "stops"];
-const causes = ["Unknown cause",
-                "Other cause",
-                "Technical problem",
-                "Strike",
-                "Demonstration",
-                "Accident",
-                "Holiday",
-                "Weather",
-                "Maintenance",
-                "Construction",
-                "Police activity",
-                "Medical emergency"];
-const effects = ["No service",
-                "Reduced service",
-                "Significant delays",
-                "Detour",
-                "Additional service",
-                "Modified service",
-                "Stop moved",
-                "Other effect",
-                "Unknown effect"];
+const files = ["trips", "routes", "stops", "agency"];
+const dropdownsIDs = [
+  "route-select",
+  "trip-select",
+  "stop-select",
+  "route-type-select",
+  "agency-select"
+]
+const textFieldIDs = [
+  "header",
+  "description",
+  "url",
+  "start-time",
+  "stop-time"
+]
+const causes = new Map([
+  [1,'Unknown Cause'],
+  [2,'Other Cause'],
+  [3,'Technical Problem'],
+  [4,'Strike'],
+  [5,'Demonstration'],
+  [6,'Accident'],
+  [7,'Holiday'],
+  [8,'Weather'],
+  [9,'Maintenance'],
+  [10,'Construction'],
+  [11,'Police Activity'],
+  [12,'Medical Emergency']
+]);
+const effects = new Map([
+  [1,'Unknown Effect'],
+  [2,'No Service'],
+  [3,'Reduced Service'],
+  [4,'Significant Delays'],
+  [5,'Detour'],
+  [6,'Additional Service'],
+  [7,'Modified Service'],
+  [8,'Other Effect'],
+  [9,'Stop Moved']
+]);
 
-var agencyID = 'pr-test';
-const baseURL = `https://storage.googleapis.com/graas-resources/gtfs-archive/${agencyID}/`;
+// May end up removing this array:
+const optionalFields = [
+  "url",
+  "agency_id",
+  "trip_id",
+  "route_id",
+  "route_type",
+  "stop_id"
+]
 
 initialize();
 
-for (let i = 0; i < files.length; i++) {
-  let fileName = files[i];
-  let url = baseURL + fileName + ".txt";
-  util.log('- fetching from ' + url);
-  util.timedFetch(url, {
-      method: 'GET'
-  })
-  .then(function(response) {
-      response.text().then(function(text){
-        fileMap.set(fileName,csvToArray(text));
-        if(fileMap.size === files.length) start();
-      })
-  })
-  .catch((error) => {
-      util.log('*** fetch() error: ' + error);
-  });
+function loadFiles(){
+  const baseURL = `https://storage.googleapis.com/graas-resources/gtfs-archive/${agencyID}/`;
+
+  for (let i = 0; i < files.length; i++) {
+    let fileName = files[i];
+    let url = baseURL + fileName + ".txt";
+    util.log('- fetching from ' + url);
+    util.timedFetch(url, {
+        method: 'GET'
+    })
+    .then(function(response) {
+        response.text().then(function(text){
+          fileMap.set(fileName,csvToArray(text));
+          if(fileName === "routes"){
+            // Manually create route-types category from routes
+            let routeTypes = getItems("routes","route_type");
+            fileMap.set("route_types", [...new Set(routeTypes)]);
+          }
+          if(fileMap.size === files.length + 1) populateDropdowns();
+        })
+    })
+    .catch((error) => {
+        util.log('*** fetch() error: ' + error);
+    });
+  }
 }
 
 function initialize(){
+  util.log("initialize()");
   let str = localStorage.getItem("app-data") || "";
 
   if (!str) {
-    util.handleModal("keyEntryModal");
+    util.showElement("keyEntryModal");
   }
   else {
     completeInitialization(util.parseAgencyData(str));
@@ -95,6 +133,60 @@ async function completeInitialization(agencyData) {
     );
 
     util.log("- signatureKey.type: " + signatureKey.type);
+    loadFiles();
+    util.handleModal("menuModal");
+}
+
+async function getPB(url){
+  let response = await fetch(url);
+  if (response.ok) {
+    const bufferRes = await response.arrayBuffer();
+    const pbf = new Pbf(new Uint8Array(bufferRes));
+    const obj = await FeedMessage.read(pbf);
+    return obj.entity;
+  } else {
+    console.error("error:", response.status);
+  }
+}
+
+async function loadFeed(){
+  let rtFeed = serverURL + "service-alerts.pb?agency=" + agencyID;
+    util.log("rtFeed: " + rtFeed);
+  feed = await getPB(rtFeed);
+  util.log("JSON.stringify(feed): " + JSON.stringify(feed));
+  // util.log("feed[0].alert.active_period.start:" + feed[0].alert.active_period.start);
+    // Add all the locations to the map:
+  const alertMap = feed.map(feedObject => {
+    let alert = feedObject.alert;
+
+    return new Object({
+      id: feedObject.id,
+      time_start: alert.active_period[0].start,
+      time_stop: alert.active_period[0].end,
+      agency_id: alert.informed_entity[0].agency_id,
+      trip_id: alert.informed_entity[0].trip_id,
+      stop_id: alert.informed_entity[0].stop_id,
+      route_id: alert.informed_entity[0].route_id,
+      route_type: alert.informed_entity[0].route_type,
+      cause: causes.get(alert.cause),
+      effect: effects.get(alert.effect),
+      header: alert.header_text.translation[0].text,
+      description: alert.description_text.translation[0].text,
+      url: (alert.url !== null ? alert.url.translation[0].text : null)
+    });
+  });
+  util.log(alertMap);
+}
+
+function handleNavigation(id){
+  util.dismissModal();
+  if(id === "create-alert-button"){
+    util.handleModal("alertCreateModal");
+  } else if(id === "view-alerts-button"){
+    loadFeed();
+  } else if(id === "menu"){
+    util.handleModal("menuModal");
+  }
 }
 
 function handleKey(id) {
@@ -128,53 +220,120 @@ function handleKey(id) {
   completeInitialization(util.parseAgencyData(value));
 }
 
-// todo: rename
-function start(){
+function populateDropdowns(){
   util.log(fileMap);
-  util.populateList("entity-select", "Select an alert entity", files);
-  util.populateList("cause-select", "Select an alert cause", causes);
-  util.populateList("effect-select", "Select an alert effect", effects);
+  if(fileMap.get("route_types").length === 1){
+    util.hideElement("route-type");
+  } else {
+    util.populateList("route-type-select", "Select a route type", fileMap.get("route_types"));
+  }
+  if(fileMap.get("agency").length === 1){
+    util.hideElement("agency");
+  } else {
+    util.populateList("agency-select", "Select an agency", getItems("agency", "agency_id"));
+  }
+  util.populateList("cause-select", "Select an alert cause", Array.from(causes.values()));
+  util.populateList("effect-select", "Select an alert effect", Array.from(effects.values()));
+  util.populateList("route-select", "Select a route", getItems("routes", "route_id"));
+  util.populateList("trip-select", "Select a trip", getItems("trips", "trip_id"));
+  util.populateList("stop-select", "Select a stop", getItems("stops", "stop_id"));
 }
 
-function handleEntityChoice(){
-  let entitySelect = document.getElementById("entity-select");
-  let entity = entitySelect.value;
-  let entitySingular = entity.slice(0,-1);
-  let id = entitySingular + "_id";
-  util.log(fileMap.get(entity));
-  var idArray = fileMap.get(entity).map(function (el) { return el[id]; });
-  util.clearSelectOptions(document.getElementById("item-select"));
-  util.populateList("item-select", "Select a " + entitySingular, idArray);
+function getItems(type, columnName){
+  return fileMap.get(type).map(function (el) { return el[columnName]; })
+}
+
+function handleEntitySelection(checkbox, entityID){
+  let dropdownName = entityID.slice(0,-8) + "select";
+  if(checkbox.checked){
+    util.showElement(dropdownName);
+  } else {
+    util.hideElement(dropdownName);
+    util.resetDropdownSelection(dropdownName);
+  }
+}
+
+function getValue(id){
+  let value = document.getElementById(id).value;
+  if(value === "disabled" || value === '') return null;
+  else return value;
 }
 
 function postServiceAlert() {
     util.log('handleGPSUpdate()');
     let timestamp = Math.floor(Date.now() / 1000);
-    let cause = document.getElementById("cause-select").value;
-    let effect = document.getElementById("effect-select").value;
-    let description = document.getElementById("description").value;
-    let header = document.getElementById("header").value;
-    // TODO: add URL
-    let url = document.getElementById("url").value;
+    let cause = getValue("cause-select");
+    let effect = getValue("effect-select");
+    let description = getValue("description");
+    let header = getValue("header");
+    let startTime = getValue("start-time");
+    let stopTime = getValue("stop-time");
+    let startTimeSecs = new Date(startTime).getTime() / 1000;
+    let stopTimeSecs = new Date(stopTime).getTime() / 1000;
+    let agency_id = getValue("agency-select");
+    let route_id = getValue("route-select");
+    let trip_id = getValue("trip-select");
+    let route_type = getValue("route-type-select");
+    let stop_id = getValue("stop-select");
+    let url = getValue("url");
+
+    if(agency_id === null && route_id === null && stop_id === null && trip_id === null && route_type === null){
+      alert("Please select at least one entity for your alert");
+      return;
+    }
+
+    if(cause === null || effect === null){
+      alert("Please select both a cause and an effect for your alert");
+      return;
+    }
+
+    if(cause === null || effect === null){
+      alert("Please assign both a cause and an effect");
+      return;
+    }
+
+    if(header === null || description === null){
+      alert("Please write both a header and a description");
+      return;
+    }
 
     let data = {
-        agency_key: agencyID,
-        cause: cause,
-        description: description,
-        effect: effect,
-        header: header,
-        time_stamp: timestamp,
-        // time_start: time_start,
-        // time_stop: time_stop
+      agency_key: agencyID,
+      timestamp: timestamp,
+      time_start: startTimeSecs,
+      time_stop: stopTimeSecs,
+      agency_id: agency_id,
+      trip_id: trip_id,
+      stop_id: stop_id,
+      route_id: route_id,
+      route_type: route_type,
+      cause: cause,
+      effect: effect,
+      header: header,
+      description: description
     };
 
-    util.log("data.cause: " + data.cause);
-    util.log("data.effect: " + data.effect);
-    util.log("data.header: " + data.header);
-    util.log("data.time_stamp: " + data.time_stamp);
+    if(url !== null){
+      urlData = {url: url}
+      Object.assign(data, urlData)
+    }
+
     util.signAndPost(data, signatureKey, '/post-alert', document);
+
+    // Consider actually confirming send status
+    alert("Alert posted successfully");
+    handleNavigation("menu");
+    resetFields();
 }
 
+function resetFields(){
+  for (let dropdown of dropdownsIDs){
+    util.resetDropdownSelection(dropdown);
+  }
+  for (let textfield of textFieldIDs){
+    util.resetFieldValue(textfield);
+  }
+}
 
 // Thanks to: https://www.bennadel.com/blog/1504-ask-ben-parsing-csv-strings-with-javascript-exec-regular-expression-command.htm
 function csvToArray(str, delimiter = ",") {

--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -87,24 +87,6 @@ function showToast(text) {
     }, 2000);
 }
 
-function handleModal(name) {
-    util.log("handleModal()");
-    util.log("- name: " + name);
-
-    currentModal = document.getElementById(name);
-    currentModal.style.display = "block";
-}
-
-function dismissModal() {
-    util.log("dismissModal()");
-    util.log("- currentModal: " + currentModal);
-
-    if (currentModal) {
-        currentModal.style.display = "none";
-        currentModal = undefined;
-    }
-}
-
 function getAssignedVehicle(assignments, blockID) {
     util.log('getAssignedVehicle()');
     util.log('- assignments: ' + assignments);
@@ -241,41 +223,20 @@ function initialize() {
     if (!str) {
         if (!isMobile()) {
             // ios WKWebView doesn't support camera access :[
-            handleModal("keyEntryModal");
+            util.handleModal("keyEntryModal");
         } else {
             // ### TODO add QR code scanning once
             // we're past the initial implementation
             //scanQRCode();
-            handleModal("keyEntryModal");
+            util.handleModal("keyEntryModal");
         }
     } else {
-        completeInitialization(parseAgencyData(str));
+        completeInitialization(util.parseAgencyData(str));
     }
-}
-
-function parseAgencyData(str) {
-    util.log("parseAgencyData()");
-    util.log("- str: " + str);
-
-    let aID = null;
-    let pem = null;
-
-    let i1 = str.indexOf(PEM_HEADER);
-    util.log("- i1: " + i1);
-
-    if (i1 > 0 && str.substring(0, i1).trim().length > 0) {
-        aID = str.substring(0, i1).trim();
-        pem = str.substring(i1);
-    }
-
-    return {
-        id: aID,
-        pem: pem
-    };
 }
 
 async function handleDeploy(data) {
-    handleModal('infiniteProgressModal');
+    util.handleModal('infiniteProgressModal');
     let json = await util.getJSONResponse('/block-collection', data, signatureKey);
     util.log('- json: ' + JSON.stringify(json));
     util.log('- json.status: ' + json);
@@ -301,8 +262,8 @@ async function handleDeploy(data) {
         updateDeploymentIndicator();
     }
 
-    dismissModal();
-    handleModal('confirmationModal');
+    util.dismissModal();
+    util.handleModal('confirmationModal');
 }
 
 function handleKey(id) {
@@ -330,11 +291,11 @@ function handleKey(id) {
             return;
         }
 
-        dismissModal();
+        util.dismissModal();
         p.value = "";
 
         localStorage.setItem('app-data', value);
-        completeInitialization(parseAgencyData(value));
+        completeInitialization(util.parseAgencyData(value));
     } else if (id === 'key-deploy') {
         let blockData = [];
         let toDate = util.nextDay(fromDate);
@@ -374,17 +335,17 @@ function handleKey(id) {
         dateStr = util.getYYYYMMDD(fromDate);
         util.log('- dateStr: ' + dateStr);
 
-        dismissModal();
+        util.dismissModal();
         loadBlockData(dateStr);
     } else if (id === 'key-select-tomorrow') {
         fromDate = util.nextDay(util.getMidnightDate());
         dateStr = util.getYYYYMMDD(fromDate);
         util.log('- dateStr: ' + dateStr);
 
-        dismissModal();
+        util.dismissModal();
         loadBlockData(dateStr);
     } else if (id === 'key-confirm-okay') {
-        dismissModal();
+        util.dismissModal();
     }
 }
 
@@ -438,7 +399,7 @@ async function completeInitialization(agencyData) {
     canvas.addEventListener('mouseup', handleMouseUp);
     canvas.addEventListener('mousemove', handleMouseMove);
 
-    handleModal('dateSelectModal');
+    util.handleModal('dateSelectModal');
 }
 
 function handleTouchStart(e) {
@@ -567,7 +528,7 @@ async function loadBlockData(dateString) {
     util.log('loadBlockData()');
     util.log('- dateString: ' + dateString);
 
-    handleModal('infiniteProgressModal');
+    util.handleModal('infiniteProgressModal');
     let name = `blocks-${dateString}.json`;
     // util.log('- name: ' + name);
     let blocks = await getGithubData(agencyID, name);
@@ -596,7 +557,7 @@ async function loadBlockData(dateString) {
 
     layout(bidList, vidList, assignments);
 
-    dismissModal();
+    util.dismissModal();
     let deployButton = document.getElementById('key-deploy');
     deployButton.style.display = readOnlyAccess ? 'none' : 'inline-block';
 }


### PR DESCRIPTION
Service alert UI summary:
- Agency login/auth via pasting secret key
- Post a service alert. Currently this relies on the user understanding trip/route/stop IDs. I've gone back and forth on this, but fear that trying to come up with names for each of them creates too many opportunities for error (ie 4 stops have the same name, or two trips are the same except for day of week - which one do we use?)
- View service alert feed (using the actual service-alert endpoint, modified to have option of showing alerts that have future start dates)
- View and delete an individual alert

Several small updates:
- Modify updateCacheIfNeeded to not error out when optional calendar_dates.txt is missing
- Move some functions from graas.js to gtfs-rt-util.js
- update TLG to use github as source of truth rather than gcloud bucket