### PR TITLE
bugfix for block data generator

### DIFF
--- a/gtfu/src/main/java/gtfu/CalendarCollection.java
+++ b/gtfu/src/main/java/gtfu/CalendarCollection.java
@@ -43,7 +43,7 @@ public class CalendarCollection implements Iterable<Calendar>, Serializable {
                 r.get("start_date"),
                 r.get("end_date"),
                 Time.parseDateAsLong(DATE_FORMAT, r.get("start_date")),
-                Time.parseDateAsLong(DATE_FORMAT, r.get("end_date"))
+                Time.parseDateAsLong(DATE_FORMAT, r.get("end_date")) + Time.MILLIS_PER_DAY
             );
 
             map.put(id, cal);


### PR DESCRIPTION
When we create the validity period for a calendar, make it so that it spans until the end of the last day, not just the beginning of the last day.

This caused problems for the block data generator for sure, but probably also led to other failures