### PR TITLE
Added reference for Code of Conduct

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,3 +7,5 @@ If you are interested in contributing to GRaaS, you hopefully have already [set 
 If you'd like to report a bug please file an Issue with a detailed description.
 
 Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard for all commits.
+
+To provide a clear expectation of how our members should interact with the project and each other, GRaaS has adopted the [Contributor Covenant Code of Conduct](https://github.com/cal-itp/graas/blob/main/docs/code-of-conduct.md).


### PR DESCRIPTION
Checked out a few different open source projects and some of them call out the code of conduct int he contribution guidelines and readme. 