### PR TITLE
fix element layout in dispatch UI

### DIFF
--- a/server/app-engine/static/vehicle-assignments.js
+++ b/server/app-engine/static/vehicle-assignments.js
@@ -150,7 +150,7 @@ function layout(blockIDList, vehicleIDList, assignments) {
 
         xx += GAP + elementWidth;
 
-        if (xx >= window.innerWidth) {
+        if (xx + elementWidth >= window.innerWidth) {
             xx = GAP;
             yy += GAP + bh;
         }
@@ -188,7 +188,7 @@ function layout(blockIDList, vehicleIDList, assignments) {
 
         xx += GAP + elementWidth;
 
-        if (xx >= window.innerWidth) {
+        if (xx + elementWidth >= window.innerWidth) {
             xx = GAP;
             yy += GAP + bh;
         }


### PR DESCRIPTION
Previously, blocks and vehicles were sometimes drawn off-screen.

Tested layout with various screen sizes and confirmed that all elements are visible.