### PR TITLE
resolve versioning issues to get pr-test working

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Python unit tests
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9.2'
+          python-version: '3.10.6'
       - run: |
           pip install -r server/app-engine/requirements.txt
           python server/tests/unit-tests.py

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -2,7 +2,7 @@ name: PR Test
 on: [pull_request]
 jobs:
   Run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
       - name: Run Python unit tests
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10.6'
+          python-version: '3.9.2'
       - run: |
           pip install -r server/app-engine/requirements.txt
           python server/tests/unit-tests.py


### PR DESCRIPTION
Our pr-test github action started failing because it runs on `ubuntu-latest`, which is a moving target. It was [upgraded from 20.04 to 22.04](https://github.com/actions/runner-images/issues/6399) last month, which no longer carried our required version of python. This change pins ubuntu to the previous version, so everything works...for now.