### PR TITLE
save raw zip file to grass-resources/gtfs-mirror/agency-name.zip

### DIFF
--- a/gtfu/src/main/java/gtfu/tools/StaticGTFSToBucket.java
+++ b/gtfu/src/main/java/gtfu/tools/StaticGTFSToBucket.java
@@ -115,7 +115,7 @@ public class StaticGTFSToBucket {
                     ZipEntry e = entries.nextElement();
                     Debug.log("-- " + e.getName());
                     byte[] bytes = Util.readInput(zip.getInputStream(e), null);
-                    gcs.uploadObject(bucketName, "gtfs-archive/" + agencyID + "/", e.getName(), bytes, "application/zip");
+                    gcs.uploadObject(bucketName, "gtfs-archive/" + agencyID + "/", e.getName(), bytes);
                 }
                 reporter.addLine("- " + agencyID);
 

--- a/gtfu/src/main/java/gtfu/tools/StaticGTFSToBucket.java
+++ b/gtfu/src/main/java/gtfu/tools/StaticGTFSToBucket.java
@@ -76,13 +76,13 @@ public class StaticGTFSToBucket {
             long lastModifiedRemote = Util.getLastModifiedRemote(gtfsURL);
             ConsoleProgressObserver progressObserver = new ConsoleProgressObserver(40);
 
-            // if (lastModifiedRemote <= lastModifiedGcloud) {
-            //     if (progressObserver != null) {
-            //         progressObserver.setMax(1);
-            //         progressObserver.update(1);
-            //     }
-            //     continue;
-            // }
+            if (lastModifiedRemote <= lastModifiedGcloud) {
+                if (progressObserver != null) {
+                    progressObserver.setMax(1);
+                    progressObserver.update(1);
+                }
+                continue;
+            }
 
             Debug.log("+ remote GTFS zip is newer than the version on gcloud, updating...");
             setLastModifiedGcloud(bucketName, agencyID, lastModifiedRemote);


### PR DESCRIPTION
I updated the existing gtfs archive process to save a copy of the raw zip file to 
 [graas-resources/gtfs-mirror](https://console.cloud.google.com/storage/browser/graas-resources/gtfs-mirror;tab=objects?project=lat-long-prototype&prefix=&forceOnObjectsSortingFiltering=false). Please look at the directory and let me know if this matches the need!