### PR TITLE
- instead of adding a click listener to the entire document body, add…

### DIFF
--- a/gtfu/src/web/index.html
+++ b/gtfu/src/web/index.html
@@ -21,7 +21,7 @@
                 <select id="date-select" onchange="handleDateChoice()" ></select>
                 <a id="click-here" onclick="showInstructions()"> Click here for instructions</a>
                 <a id="download" target="_blank">
-                    <button type="button">Download</button>
+                    <button id="download-button" type="button">Download</button>
                 </a>
             </div>
             <canvas id="timeline" ></canvas>


### PR DESCRIPTION
- instead of adding a click listener to the entire document body, add only to timeline and map canvas
- previous download mechanism doesn't really work anymore, since routes are now drawn dynamically on top of static images
- implement functiong download as
  + create offscreen canvas
  + draw contents of timeline and maps canvas to offscreen canvas
  + convert canvas contents to data URL
  + trigger download of data URL to client machine