### PR TITLE
automation groundwork

### DIFF
--- a/.github/workflows/graas-bot.yaml
+++ b/.github/workflows/graas-bot.yaml
@@ -1,0 +1,29 @@
+name: Collect daily GRaaS bot stats
+on:
+  # Daily at 11PM pacific
+  schedule:
+    - cron: '0 6 * * *'
+jobs:
+  Run-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          node-version: '16.1.0'
+      - name: Setup Cloud SDK
+        uses: google-github-actions/auth@v0
+        with:
+          # Google recommends using a Workload Identify Federation instead of using the service account key json file
+          # but this method is continuing to be supported. More info: https://github.com/google-github-actions/auth#setup
+          service_account: 'lat-long-prototype@appspot.gserviceaccount.com'
+          credentials_json: ${{ secrets.GCP_SA_KEY_JSON }}
+      - name: Run Python unit tests
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.2'
+      - run: |
+          pip install -r server/app-engine/requirements.txt
+          python server/app-engine/graas_bot.py
+        env:
+          GRAAS_BOT_WEBHOOK: ${{ secrets.GRAAS_BOT_WEBHOOK }}

--- a/server/app-engine/ecdsa-test.py
+++ b/server/app-engine/ecdsa-test.py
@@ -1,7 +1,8 @@
 import ecdsa
 
 #sk = ecdsa.SigningKey.generate(curve=ecdsa.SECP256k1)
-print(f'- ecdsa: {ecdsa}')
+#print(f'- ecdsa: {dir(ecdsa)}')
+print(f'- ecdsa.__version__: {ecdsa.__version__}')
 sk = ecdsa.SigningKey.generate(curve=ecdsa.NIST256p)
 skpem = sk.to_pem(format='pkcs8').decode('utf-8')
 print(f'- skpem:\n{skpem}')

--- a/server/app-engine/graas_bot.py
+++ b/server/app-engine/graas_bot.py
@@ -171,7 +171,7 @@ def main(argv):
     print(f'- end_time  : {end_time}')
 
     kinds = ['position', 'alert']
-    counts = {'position': 8131, 'alert': 0}
+    counts = {'position': 0, 'alert': 0}
     agencies = set()
 
     for k in kinds:

--- a/server/app-engine/graas_bot.py
+++ b/server/app-engine/graas_bot.py
@@ -1,0 +1,90 @@
+import requests
+import sys
+from google.cloud import datastore
+from datetime import date, datetime
+import os
+import warnings
+import time
+
+
+def get_cutoff_seconds(str):
+    splitat = len(str) - 1
+    num, unit = str[:splitat], str[splitat:]
+    # print('num: ', num)
+    # print('unit: ', unit)
+    if unit == 'm':
+        return int(num) * 60
+    if unit == 'h':
+        return int(num) * 60 * 60
+    if unit == 'd':
+        return int(num) * 60 * 60 * 24
+    raise ValueError('cutoff must be given as \'[num]m|h|d\'')
+
+def midnight_seconds(date_string=None):
+    if date_string is None:
+        tm = datetime.now()
+    else:
+        tm = datetime.strptime(date_string, '%m/%d/%y')
+    tm = tm.replace(hour=0, minute=0, second=0, microsecond=0)
+    return int(tm.timestamp())
+
+def get_db_entries(datastore_client, entry_kind, start_time, end_time):
+    query = datastore_client.query(kind=entry_kind)
+
+    query.add_filter('timestamp', '>=', start_time)
+    query.add_filter('timestamp', '<=', end_time)
+
+    entries =  query.fetch()
+
+    return entries
+
+def main(argv):
+    webhook = os.environ.get('GRAAS_BOT_WEBHOOK', 'not found')
+
+    if webhook == 'not found':
+        print('please set env variable "GRAAS_BOT_WEBHOOK"')
+        exit(1)
+
+    datastore_client = datastore.Client()
+
+    end_time = int(round(time.time()))
+    start_time = end_time - 86400
+
+    print(f'- start_time: {start_time}')
+    print(f'- end_time  : {end_time}')
+
+    kinds = ['position', 'alert']
+    counts = {'position': 0, 'alert': 0}
+    agencies = set()
+
+    for k in kinds:
+        for pos in get_db_entries(datastore_client, k, start_time, end_time):
+            ts = pos.get('timestamp', 'not found')
+
+            counts[k] = counts[k] + 1
+
+            agency = pos.get('agency-id', 'not found')
+
+            if agency != 'not found':
+                agencies.add(agency)
+
+    output = f':bar_chart: *Statistics*\n'
+    output += f'- Update Counts\n'
+
+    for c in counts:
+        output += f'  - {c}: {counts[c]}\n'
+
+    if len(agencies) > 0:
+        output += f'- Active Agencies\n'
+
+    for a in agencies:
+        output += f'  - {a}\n'
+
+    print(output)
+
+    payload = f'{{"text": "{output}"}}'
+    result = requests.post(webhook, payload)
+    print(f'- result: {result}')
+
+if __name__ == '__main__':
+   main(sys.argv[1:])

--- a/server/app-engine/graas_bot.py
+++ b/server/app-engine/graas_bot.py
@@ -1,32 +1,149 @@
 import requests
 import sys
 from google.cloud import datastore
-from datetime import date, datetime
 import os
-import warnings
 import time
 
+# 'all-your-base' -> 'All Your Base'
+def to_display_name(s):
+    r = ''
+    last_c = '-'
 
-def get_cutoff_seconds(str):
-    splitat = len(str) - 1
-    num, unit = str[:splitat], str[splitat:]
-    # print('num: ', num)
-    # print('unit: ', unit)
-    if unit == 'm':
-        return int(num) * 60
-    if unit == 'h':
-        return int(num) * 60 * 60
-    if unit == 'd':
-        return int(num) * 60 * 60 * 24
-    raise ValueError('cutoff must be given as \'[num]m|h|d\'')
+    for c in s:
+        if c == '-':
+            r += ' '
+        elif c.islower() and last_c == '-':
+            r += c.upper()
+        else:
+            r += c
 
-def midnight_seconds(date_string=None):
-    if date_string is None:
-        tm = datetime.now()
-    else:
-        tm = datetime.strptime(date_string, '%m/%d/%y')
-    tm = tm.replace(hour=0, minute=0, second=0, microsecond=0)
-    return int(tm.timestamp())
+        last_c = c
+
+    return r
+
+"""
+
+Generate an ASCII table similar to the example below based on input
+- counts: dictionary with client message names and counts
+- agencies: set of agency IDs
+
++------------------------------------------+
+| Client Updates                           |
++----+----------+--------------------------+
+|    | Position |                    8,131 |
+|    +----------+--------------------------+
+|    | Alert    |                        0 |
++----+----------+--------------------------+
+| Active Agencies                          |
++----+-------------------------------------+
+|    | Altamont Corridor Express           |
+|    +-------------------------------------+
+|    | Santa Ynez Valley Transport         |
++----+-------------------------------------+
+"""
+def make_ascii_table(counts, agencies):
+    alist = list(agencies)
+    alist.sort()
+    print(f'- alist: {alist}')
+
+    maxalen = 0
+
+    for a in alist:
+        if len(a) > maxalen:
+            maxalen = len(a)
+
+    print(f'- maxalen: {maxalen}')
+
+    maxklen = 0
+
+    for k in counts:
+        if len(k) > maxklen:
+            maxklen = len(k)
+
+    print(f'- maxklen: {maxklen}')
+
+    rowlen = maxalen + 17
+    print(f'- rowlen: {rowlen}')
+    output = ''
+
+    line = '+'
+    line = line.ljust(rowlen - 1, '-')
+    line += '+\n'
+    output += line
+
+    line = '| Client Updates'
+    line = line.ljust(rowlen - 1, ' ')
+    line += '|\n'
+    output += line
+
+    line = '+----+-'
+    line = line.ljust(len(line) + maxklen, '-')
+    line += '-+'
+    line = line.ljust(rowlen - 1, '-')
+    line += '+\n'
+    output += line
+
+    i = 0
+    for c in counts:
+        line = '|    | '
+        line += to_display_name(c)
+        line = line.ljust(len(line) + maxklen - len(c), ' ')
+        line += ' |'
+        num = f'{counts[c]:,}'
+        line = line.ljust(rowlen - len(num) - 2, ' ')
+        line += num
+        line += ' |\n'
+        output += line
+
+        if i < len(counts) - 1:
+            line = '|    +-'
+            line = line.ljust(len(line) + len(c), '-')
+            line += '-+-'
+            line = line.ljust(rowlen - 1, '-')
+            line += '+\n'
+            output += line
+        else:
+            line = '+----+-'
+            line = line.ljust(len(line) + maxklen, '-')
+            line += '-+'
+            line = line.ljust(rowlen - 1, '-')
+            line += '+\n'
+            output += line
+
+        i = i + 1
+
+    line = '| Active Agencies'
+    line = line.ljust(rowlen - 1, ' ')
+    line += '|\n'
+    output += line
+
+    line = '+----+-'
+    line = line.ljust(rowlen - 1, '-')
+    line += '+\n'
+    output += line
+
+    i = 0
+    for a in alist:
+        line = '|    | '
+        line += to_display_name(a)
+        line = line.ljust(rowlen - 2, ' ')
+        line += ' |\n'
+        output += line
+
+        if i < len(alist) - 1:
+            line = '|    +-'
+            line = line.ljust(rowlen - 1, '-')
+            line += '+\n'
+            output += line
+        else:
+            line = '+----+-'
+            line = line.ljust(rowlen - 1, '-')
+            line += '+\n'
+            output += line
+
+        i = i + 1
+
+    return output
 
 def get_db_entries(datastore_client, entry_kind, start_time, end_time):
     query = datastore_client.query(kind=entry_kind)
@@ -54,7 +171,7 @@ def main(argv):
     print(f'- end_time  : {end_time}')
 
     kinds = ['position', 'alert']
-    counts = {'position': 0, 'alert': 0}
+    counts = {'position': 8131, 'alert': 0}
     agencies = set()
 
     for k in kinds:
@@ -68,19 +185,12 @@ def main(argv):
             if agency != 'not found':
                 agencies.add(agency)
 
-    output = f':bar_chart: *Statistics*\n'
-    output += f'- Update Counts\n'
+    output = ':bar_chart: *Stats for the Past 24 Hours*\n'
+    output += '```\n'
+    output += make_ascii_table(counts, agencies)
+    output += '```\n'
 
-    for c in counts:
-        output += f'  - {c}: {counts[c]}\n'
-
-    if len(agencies) > 0:
-        output += f'- Active Agencies\n'
-
-    for a in agencies:
-        output += f'  - {a}\n'
-
-    print(output)
+    print('\n' + output)
 
     payload = f'{{"text": "{output}"}}'
     result = requests.post(webhook, payload)

--- a/server/app-engine/main.py
+++ b/server/app-engine/main.py
@@ -396,7 +396,7 @@ def verify_request(request, cmd):
         print('- verified: ' + str(verified))
 
         if not verified:
-            print(f'*** could not verify signature for command {cmd}, discarding')
+            print(f'*** could not verify signature for agency "{agency}"command "{cmd}", discarding...')
             return {
                 'verified': False,
                 'response': Response(f'{{"command": {cmd}, "status": "unverified"}}', mimetype='application/json')

--- a/server/app-engine/requirements.txt
+++ b/server/app-engine/requirements.txt
@@ -5,7 +5,7 @@ requests==2.23.0
 gtfs-realtime-bindings==0.0.7
 six==1.14.0
 pycryptodome==3.15.0
-ecdsa==0.16.0
+ecdsa==0.18.0
 google-cloud-ndb==1.11.1
 google-cloud-storage==1.43.0
 itsdangerous==2.0.1

--- a/server/app-engine/static/graas.js
+++ b/server/app-engine/static/graas.js
@@ -924,24 +924,12 @@ async function initializeCallback(agencyData) {
         util.log("- key.type: " + key.type);
         signatureKey = key;
 
-        let str = 'hello ' + Math.floor(Date.now() / 1000);
-
-        let buf = await util.sign(str, signatureKey)
-
-        let sig = btoa(util.ab2str(buf));
-        util.log(`sig: ${sig}`);
-        let hello = {
-            msg: str,
-            sig: sig
+        let data = {
+            text: 'hello ' + Math.floor(Date.now() / 1000),
+            agency_id: agencyData.id,
         };
 
-        if (agencyData.id) {
-            hello.id = agencyData.id;
-        }
-
-        util.log("- hello: " + JSON.stringify(hello));
-
-        let response = await util.apiCall(hello, '/hello');
+        let response = await util.signAndPost(data, signatureKey, '/hello');
         let responseJson = await response.json();
         util.log("- responseJson: " + JSON.stringify(responseJson));
         keyVerificationCallback(responseJson, agencyData);


### PR DESCRIPTION
- create grass bot that collects usage stats and posts to slack channel at 11 pm PT every day
- make all server endpoints follow the designated signature verification approach, instead of fragmented local variations
- fix issues around initial token verification 
- allow python code to produce grass-compatible ECDSA keys with a couple of lines of code, instead of tedious command line sequences or brittle system calls from within python (see ecdsa-test.py for an example on how to generate)
- tested token verification, position updates and alert updates